### PR TITLE
Fix missing typer import

### DIFF
--- a/vea/utils/generic_utils.py
+++ b/vea/utils/generic_utils.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 from typing import Optional
 import logging
+import typer
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- add `typer` import in `generic_utils`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5adaa9bc832c8449c481b3047c4c