### PR TITLE
Add tests for parse_week_input

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path so tests can import the package
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_date_utils.py
+++ b/tests/test_date_utils.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timedelta
+
+from vea.utils.date_utils import parse_week_input
+
+
+def test_parse_week_input_year_with_w():
+    start, end = parse_week_input("2025-W22")
+    expected_start = datetime.strptime("2025-W22-1", "%G-W%V-%u").date()
+    assert start == expected_start
+    assert end == expected_start + timedelta(days=6)
+
+
+def test_parse_week_input_year_without_w():
+    start, end = parse_week_input("2025-22")
+    expected_start = datetime.strptime("2025-W22-1", "%G-W%V-%u").date()
+    assert start == expected_start
+    assert end == expected_start + timedelta(days=6)
+
+
+def test_parse_week_input_week_only():
+    year = datetime.today().year
+    start, end = parse_week_input("22")
+    expected_start = datetime.strptime(f"{year}-W22-1", "%G-W%V-%u").date()
+    assert start == expected_start
+    assert end == expected_start + timedelta(days=6)
+
+
+def test_parse_week_input_from_date():
+    start, end = parse_week_input("2025-05-28")
+    expected_start = datetime.strptime("2025-W22-1", "%G-W%V-%u").date()
+    assert start == expected_start
+    assert end == expected_start + timedelta(days=6)


### PR DESCRIPTION
## Summary
- add `tests/conftest.py` to put project on `sys.path`
- add `tests/test_date_utils.py` with coverage for `parse_week_input`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5af24ed8832ca70f9edcb9b26cbe