### PR TITLE
Fix path option and PDF debug

### DIFF
--- a/vea/cli.py
+++ b/vea/cli.py
@@ -128,7 +128,7 @@ def generate_weekly_summary(
     extras_dir: Optional[Path] = typer.Option(None, help="Directory with additional Markdown files"),
     save_markdown: bool = typer.Option(False, help="Save output as markdown file."),
     save_pdf: bool = typer.Option(False, help="Save output as PDF."),
-    save_path: Optional[str] = typer.Option(None, help="Optional override path to save output."),
+    save_path: Optional[Path] = typer.Option(None, help="Optional override path to save output."),
     model: str = typer.Option("gemini-2.5-pro-preview-05-06", help="Model to use for summarization (OpenAI, Google Gemini, or Anthropic)"),
     skip_path_checks: bool = typer.Option(False, help="Skip path existence checks."),
     debug: bool = typer.Option(False, help="Enable debug logging"),
@@ -180,13 +180,13 @@ def generate_weekly_summary(
 
         if save_markdown or save_pdf:
             filename = f"{week_start.isocalendar().year}-W{week_start.isocalendar().week:02d}.md"
-            md_path = resolve_output_path(Path(save_path) if save_path else None, week_start, custom_filename=filename)
+            md_path = resolve_output_path(save_path, week_start, custom_filename=filename)
 
             if save_markdown:
                 md_path.write_text(summary, encoding="utf-8")
 
             if save_pdf:
-                convert_markdown_to_pdf(summary, md_path.with_suffix(".pdf"))
+                convert_markdown_to_pdf(summary, md_path.with_suffix(".pdf"), debug=debug)
 
     except Exception as e:
         handle_exception(e)

--- a/vea/utils/generic_utils.py
+++ b/vea/utils/generic_utils.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import Optional
 import logging
@@ -7,8 +6,16 @@ import typer
 logger = logging.getLogger(__name__)
 
 
-def check_required_directories(journal_dir: Optional[str], extras_dir: Optional[str], save_path: Optional[str]) -> None:
-    for path_name, path in [('journal_dir', journal_dir), ('extras_dir', extras_dir), ('save_path', save_path)]:
-        if path and not os.path.isdir(path):
+def check_required_directories(
+    journal_dir: Optional[Path],
+    extras_dir: Optional[Path],
+    save_path: Optional[Path]
+) -> None:
+    for path_name, path in [
+        ("journal_dir", journal_dir),
+        ("extras_dir", extras_dir),
+        ("save_path", save_path),
+    ]:
+        if path and not Path(path).is_dir():
             typer.echo(f"Error: Provided path for {path_name} does not exist: {path}", err=True)
             raise typer.Exit(code=1)


### PR DESCRIPTION
## Summary
- standardize `save_path` parameter type for weekly command
- pass debug flag when generating PDF for weekly summaries
- update path validation helper to work with `Path` objects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fdccfa46c832c8b4fc96ed7103985