### PR TITLE
Add skip past events option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ vea daily \
   --save-path ~/DailyBrief/ \
   --todoist-project "My Todoist Project" \
   --calendar-blacklist "Lunch, Focus time" \
+  --skip-past-events \
   --save-markdown
 ```
 
@@ -71,6 +72,7 @@ vea daily \
 - `--extras-dir`: Directory with extra `.md` files (e.g. notes, projects)
 - `--todoist-project`: Filter tasks by Todoist project
 - `--calendar-blacklist`: Additional substrings to filter out calendar events (adds to .env)
+- `--skip-past-events`: Ignore calendar events that have already started today
 - `--model`: Use a specific LLM (e.g., `o4-mini`, `claude-3-7-sonnet-latest`, or `gemini-2.5-pro-preview-05-06`)
 - `--quiet`: Suppress printing output to the console
 - `--debug`: Outputs debug information to the console

--- a/tests/test_gcal.py
+++ b/tests/test_gcal.py
@@ -1,0 +1,110 @@
+from datetime import datetime, timedelta
+import sys
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
+from datetime import tzinfo
+
+class _FakeTZ(tzinfo):
+    def __init__(self, name):
+        self._zone = ZoneInfo(name)
+
+    def localize(self, dt):
+        return dt.replace(tzinfo=self)
+
+    def utcoffset(self, dt):
+        return self._zone.utcoffset(dt)
+
+    def dst(self, dt):
+        return self._zone.dst(dt)
+
+    def tzname(self, dt):
+        return self._zone.tzname(dt)
+
+sys.modules.setdefault(
+    "pytz",
+    SimpleNamespace(timezone=lambda name: _FakeTZ(name), UTC=_FakeTZ("UTC")),
+)
+
+# Stub google credentials and discovery modules if missing
+class _DummyCreds:
+    pass
+
+class _DummyDiscovery:
+    @staticmethod
+    def build(*args, **kwargs):
+        return None
+
+sys.modules.setdefault("google.oauth2.credentials", SimpleNamespace(Credentials=_DummyCreds))
+sys.modules.setdefault("googleapiclient.discovery", SimpleNamespace(build=_DummyDiscovery.build))
+
+import pytz
+
+import vea.loaders.gcal as gcal
+
+class DummyCreds:
+    pass
+
+class DummyService:
+    def __init__(self, items):
+        self._items = items
+    def events(self):
+        return self
+    def list(self, **kwargs):
+        return self
+    def execute(self):
+        return {"items": self._items}
+
+def make_event(summary, start, end, all_day=False):
+    if all_day:
+        return {"summary": summary, "start": {"date": start}, "end": {"date": end}}
+    return {"summary": summary, "start": {"dateTime": start}, "end": {"dateTime": end}}
+
+
+def test_skip_past_events(monkeypatch):
+    tz = pytz.timezone("Europe/Amsterdam")
+    now = datetime.now(tz).replace(microsecond=0)
+    past = now - timedelta(hours=1)
+    future = now + timedelta(hours=1)
+
+    items = [
+        make_event("Past", past.isoformat(), past.isoformat()),
+        make_event("Future", future.isoformat(), future.isoformat()),
+        make_event("AllDay", now.date().isoformat(), now.date().isoformat(), all_day=True),
+    ]
+
+    monkeypatch.setattr(
+        gcal,
+        "Credentials",
+        SimpleNamespace(from_authorized_user_file=lambda *a, **k: DummyCreds()),
+    )
+    monkeypatch.setattr(gcal, "build", lambda *a, **k: DummyService(items))
+
+    events = gcal.load_events(now.date(), my_email="me@example.com", skip_past_events=True)
+    summaries = [e["summary"] for e in events]
+    assert "Past" not in summaries
+    assert "Future" in summaries
+    assert "AllDay" in summaries
+
+
+def test_no_skip_past_events(monkeypatch):
+    tz = pytz.timezone("Europe/Amsterdam")
+    now = datetime.now(tz).replace(microsecond=0)
+    past = now - timedelta(hours=1)
+    future = now + timedelta(hours=1)
+
+    items = [
+        make_event("Past", past.isoformat(), past.isoformat()),
+        make_event("Future", future.isoformat(), future.isoformat()),
+    ]
+
+    monkeypatch.setattr(
+        gcal,
+        "Credentials",
+        SimpleNamespace(from_authorized_user_file=lambda *a, **k: DummyCreds()),
+    )
+    monkeypatch.setattr(gcal, "build", lambda *a, **k: DummyService(items))
+
+    events = gcal.load_events(now.date(), my_email="me@example.com", skip_past_events=False)
+    summaries = [e["summary"] for e in events]
+    assert "Past" in summaries
+    assert "Future" in summaries

--- a/vea/cli.py
+++ b/vea/cli.py
@@ -49,6 +49,10 @@ def generate(
         None,
         help="Comma-separated list of keywords to blacklist from calendar events (overrides CALENDAR_EVENT_BLACKLIST)"
     ),
+    skip_past_events: bool = typer.Option(
+        False,
+        help="Skip calendar events earlier than the current time when generating today's brief",
+    ),
     save_markdown: bool = typer.Option(True, help="Save output to Markdown file"),
     save_pdf: bool = typer.Option(False, help="Save output to PDF file"),
     save_path: Optional[Path] = typer.Option(None, help="Custom file path or directory to save the output"),
@@ -83,7 +87,12 @@ def generate(
             if journal_dir
             else []
         )
-        calendars = gcal.load_events(target_date, my_email=my_email, blacklist=calendar_blacklist)
+        calendars = gcal.load_events(
+            target_date,
+            my_email=my_email,
+            blacklist=calendar_blacklist,
+            skip_past_events=skip_past_events,
+        )
         tasks = todoist.load_tasks(target_date, os.getenv("TODOIST_TOKEN", ""), todoist_project or "")
         emails = gmail.load_emails(target_date, gmail_labels=gmail_labels)
         slack_data = slack_loader.load_slack_messages() if include_slack else {}


### PR DESCRIPTION
## Summary
- allow skipping past calendar events in the daily brief with `--skip-past-events`
- filter events in `load_events` based on current time when option enabled
- document new option in README and example
- test event skipping logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fe65e54fc832caa41218ed314c5e5