### PR TITLE
Add custom prompt file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Below is a complete list of options for `vea daily` (run `vea daily --help` to s
 - `--save-markdown / --no-save-markdown` – Write the summary to a Markdown file (default: true)
 - `--save-pdf` – Save the summary as a PDF
 - `--save-path` – Custom file path or directory for the output
+- `--prompt-file` – Path to a custom prompt file
 - `--model` – LLM to use for summarization (e.g. `o4-mini`, `claude-3-7-sonnet-latest`, `gemini-2.5-pro-preview-05-06`)
 - `--skip-path-checks` – Skip validation of input/output paths
 - `--debug` – Enable debug logging
@@ -111,6 +112,7 @@ Run `vea weekly --help` to see all options. The main ones are:
 - `--save-markdown` – Write the weekly summary to a Markdown file
 - `--save-pdf` – Save the summary as a PDF
 - `--save-path` – Custom output directory or file path
+- `--prompt-file` – Path to a custom prompt file
 - `--model` – LLM used for summarization
 - `--skip-path-checks` – Skip validation of input/output paths
 - `--debug` – Enable debug logging

--- a/vea/cli.py
+++ b/vea/cli.py
@@ -56,6 +56,7 @@ def generate(
     save_markdown: bool = typer.Option(True, help="Save output to Markdown file"),
     save_pdf: bool = typer.Option(False, help="Save output to PDF file"),
     save_path: Optional[Path] = typer.Option(None, help="Custom file path or directory to save the output"),
+    prompt_file: Optional[Path] = typer.Option(None, help="Path to custom prompt file"),
     model: str = typer.Option("gemini-2.5-pro-preview-05-06", help="Model to use for summarization (OpenAI, Google Gemini, or Anthropic)"),
     skip_path_checks: bool = typer.Option(False, help="Skip checks for existence of input and output paths"),
     debug: bool = typer.Option(False, help="Enable debug logging"),
@@ -68,7 +69,7 @@ def generate(
     if not skip_path_checks:
         check_required_directories(journal_dir, extras_dir, save_path)
 
-    prompt_path = Path(__file__).parent / "prompts" / "daily-default.prompt"
+    prompt_path = prompt_file or Path(__file__).parent / "prompts" / "daily-default.prompt"
     if not prompt_path.is_file():
         typer.echo(f"Error: Default prompt file does not exist: {prompt_path}", err=True)
         raise typer.Exit(code=1)
@@ -108,6 +109,7 @@ def generate(
             extras=extras_data,
             slack=slack_data,
             bio=bio,
+            prompt_path=prompt_path,
             quiet=quiet,
             debug=debug,
         )
@@ -138,6 +140,7 @@ def generate_weekly_summary(
     save_markdown: bool = typer.Option(False, help="Save output as markdown file."),
     save_pdf: bool = typer.Option(False, help="Save output as PDF."),
     save_path: Optional[Path] = typer.Option(None, help="Optional override path to save output."),
+    prompt_file: Optional[Path] = typer.Option(None, help="Path to custom prompt file"),
     model: str = typer.Option("gemini-2.5-pro-preview-05-06", help="Model to use for summarization (OpenAI, Google Gemini, or Anthropic)"),
     skip_path_checks: bool = typer.Option(False, help="Skip path existence checks."),
     debug: bool = typer.Option(False, help="Enable debug logging"),
@@ -149,7 +152,7 @@ def generate_weekly_summary(
     if not skip_path_checks:
         check_required_directories(journal_dir, extras_dir, save_path)
 
-    prompt_path = Path(__file__).parent / "prompts" / "weekly-default.prompt"
+    prompt_path = prompt_file or Path(__file__).parent / "prompts" / "weekly-default.prompt"
     if not prompt_path.is_file():
         typer.echo(f"Error: Default prompt file does not exist: {prompt_path}", err=True)
         raise typer.Exit(code=1)
@@ -180,6 +183,7 @@ def generate_weekly_summary(
             journals_contextual=journals_contextual,
             extras=extras_data,
             bio=bio,
+            prompt_path=prompt_path,
             quiet=quiet,
             debug=debug,
         )

--- a/vea/utils/summarization.py
+++ b/vea/utils/summarization.py
@@ -71,9 +71,10 @@ def summarize_daily(
     bio: str = "",
     quiet: bool = False,
     debug: bool = False,
+    prompt_path: Optional[Path] = None,
 ) -> str:
 
-    prompt_template = load_prompt_template()
+    prompt_template = load_prompt_template(prompt_path)
     prompt = render_daily_prompt(
         prompt_template,
         date=date,
@@ -105,8 +106,9 @@ def summarize_weekly(
     bio: str = "",
     quiet: bool = False,
     debug: bool = False,
+    prompt_path: Optional[Path] = None,
 ) -> str:
-    template = load_prompt_template(APP_WEEKLY_PROMPT_PATH)
+    template = load_prompt_template(prompt_path or APP_WEEKLY_PROMPT_PATH)
     prompt = template.format(
         week=week,
         journals_in_week=json.dumps(journals_in_week, indent=2, default=str, ensure_ascii=False),


### PR DESCRIPTION
## Summary
- allow passing `--prompt-file` to `vea daily` and `vea weekly`
- support custom prompt path in summarization helpers
- document new command line option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff6b35530832cb1b687681f37d406