### PR TITLE
Add prepare-event command

### DIFF
--- a/vea/prompts/prepare-event.prompt
+++ b/vea/prompts/prepare-event.prompt
@@ -1,0 +1,34 @@
+You are Vea, the Chief of Staff supporting a senior leader.
+
+> {bio}
+
+Using the collected data below, produce **last-minute insights** for the upcoming calendar event(s).
+Focus on what will help the leader prepare effectively: related topics, mentions of the event or its participants, open questions, reminders, and any sensitive context.
+
+### Output Format
+For each event, output:
+1. **Event** – Title, start time (include timezone if provided), and list of known attendees if available.
+2. **Insights** – A bullet list (1–3 items) with the most relevant information.
+
+Do not add introductions or closing remarks. Render valid Markdown only.
+
+---
+
+### Events (JSON)
+{events}
+
+### Journals (JSON)
+{journals}
+
+### Additional Notes (JSON)
+{extras}
+
+### Emails (JSON)
+{emails}
+
+### Slack Messages (JSON)
+{slack}
+
+---
+
+Now generate the insights.

--- a/vea/utils/slack_utils.py
+++ b/vea/utils/slack_utils.py
@@ -1,0 +1,24 @@
+import os
+import logging
+from typing import Optional
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
+logger = logging.getLogger(__name__)
+
+
+def send_slack_dm(message: str, *, token: Optional[str] = None) -> None:
+    """Send a direct message to the authenticated user."""
+    token = token or os.environ.get("SLACK_TOKEN")
+    if not token:
+        logger.warning("SLACK_TOKEN not set; cannot send Slack DM")
+        return
+
+    client = WebClient(token=token)
+    try:
+        user_id = client.auth_test()["user_id"]
+        channel_id = client.conversations_open(users=user_id)["channel"]["id"]
+        client.chat_postMessage(channel=channel_id, text=message)
+        logger.info("Sent Slack DM to user")
+    except SlackApiError as e:
+        logger.warning(f"Failed to send Slack DM: {e.response['error']}")

--- a/vea/utils/summarization.py
+++ b/vea/utils/summarization.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 APP_ROOT = Path(__file__).resolve().parents[2]
 PROMPT_TEMPLATE_PATH = APP_ROOT / "vea" / "prompts" / "daily-default.prompt"
 APP_WEEKLY_PROMPT_PATH = APP_ROOT / "vea/prompts/weekly-default.prompt"
+APP_PREPARE_EVENT_PROMPT_PATH = APP_ROOT / "vea/prompts/prepare-event.prompt"
 
 
 def load_prompt_template(path: Optional[Path] = None) -> str:
@@ -115,6 +116,37 @@ def summarize_weekly(
         journals_contextual=json.dumps(journals_contextual, indent=2, default=str, ensure_ascii=False),
         extras=json.dumps(extras, indent=2, default=str, ensure_ascii=False),
         bio=bio
+    )
+
+    if debug:
+        logger.debug("========== BEGIN PROMPT ==========")
+        logger.debug(prompt)
+        logger.debug("=========== END PROMPT ===========")
+
+    return run_llm_prompt(prompt, model)
+
+
+def summarize_event_preparation(
+    model: str,
+    events: List[dict],
+    journals: List,
+    extras: List,
+    emails: Dict,
+    slack: Optional[Dict[str, List[Dict[str, str]]]] = None,
+    bio: str = "",
+    debug: bool = False,
+    prompt_path: Optional[Path] = None,
+) -> str:
+    """Summarize last-minute insights for upcoming events."""
+
+    template = load_prompt_template(prompt_path or APP_PREPARE_EVENT_PROMPT_PATH)
+    prompt = template.format(
+        bio=bio,
+        events=json.dumps(events, indent=2, default=str, ensure_ascii=False),
+        journals=json.dumps(journals, indent=2, default=str, ensure_ascii=False),
+        extras=json.dumps(extras, indent=2, default=str, ensure_ascii=False),
+        emails=json.dumps(emails, indent=2, default=str, ensure_ascii=False),
+        slack=json.dumps(slack, indent=2, default=str, ensure_ascii=False) if slack else "",
     )
 
     if debug:


### PR DESCRIPTION
## Summary
- add prepare-event.prompt with instructions for last-minute insights
- implement `summarize_event_preparation` in summarization utils
- add Slack DM helper
- introduce new `prepare-event` CLI command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400a3cf360832c8dad6254e9899538