### PR TITLE
Add prepare-event command

### DIFF
--- a/vea/cli.py
+++ b/vea/cli.py
@@ -15,7 +15,14 @@ from vea.auth import authorize
 from vea.utils.date_utils import parse_date, parse_week_input
 from vea.utils.output_utils import resolve_output_path
 from vea.utils.error_utils import enable_debug_logging, handle_exception
-from vea.utils.summarization import summarize_daily, summarize_weekly
+from vea.utils.summarization import (
+    summarize_daily,
+    summarize_weekly,
+    summarize_event_preparation,
+)
+from vea.utils.slack_utils import send_slack_dm
+import pytz
+from datetime import timedelta
 from vea.utils.pdf_utils import convert_markdown_to_pdf
 from vea.utils.generic_utils import check_required_directories
 
@@ -25,12 +32,159 @@ app = typer.Typer(help="Vea: Generate a personalized daily briefing or weekly su
 load_dotenv()
 
 
+def _parse_event_dt(dt_str: str) -> datetime:
+    tz = pytz.timezone("Europe/Amsterdam")
+    dt = datetime.strptime(dt_str, "%Y-%m-%d %H:%M")
+    return tz.localize(dt)
+
+
+def _find_upcoming_events(
+    *,
+    start: datetime,
+    my_email: Optional[str],
+    blacklist: Optional[List[str]],
+) -> List[dict]:
+    tz = pytz.timezone("Europe/Amsterdam")
+    current = start.astimezone(tz)
+    for offset in range(7):
+        day = current.date() + timedelta(days=offset)
+        events = gcal.load_events(
+            day,
+            my_email=my_email,
+            blacklist=blacklist,
+            skip_past_events=(offset == 0),
+        )
+        timed = [e for e in events if "T" in e.get("start", "")]
+        if not timed:
+            continue
+        def _dt(ev):
+            dt = datetime.fromisoformat(ev["start"])
+            if dt.tzinfo is None:
+                dt = tz.localize(dt)
+            return dt
+        starts = [_dt(e) for e in timed]
+        eligible = [e for e, dtval in zip(timed, starts) if dtval >= current]
+        if not eligible:
+            continue
+        start_times = [_dt(e) for e in eligible]
+        earliest = min(start_times)
+        return [e for e, dtval in zip(eligible, start_times) if dtval == earliest]
+    return []
+
+
 @app.command("auth")
 def auth_command(
     scopes: List[str] = typer.Argument(..., help="Services to authorize (e.g., `calendar gmail`)")
 ) -> None:
     try:
         authorize(scopes)
+    except Exception as e:
+        handle_exception(e)
+
+
+@app.command("prepare-event")
+def prepare_event(
+    event: Optional[str] = typer.Option(
+        None,
+        help="Event start time to prepare for (YYYY-MM-DD HH:MM). If omitted, use the next upcoming event.",
+    ),
+    journal_dir: Optional[Path] = typer.Option(None, help="Directory with Markdown journal files"),
+    journal_days: int = typer.Option(21, help="Number of past days of journals to include"),
+    extras_dir: Optional[Path] = typer.Option(None, help="Directory with additional Markdown files"),
+    gmail_labels: Optional[List[str]] = typer.Option(None, help="List of additional Gmail labels to fetch emails from"),
+    todoist_project: Optional[str] = typer.Option(None, help="Name of the Todoist project to filter tasks by"),
+    my_email: Optional[str] = typer.Option(None, help="Your email address to filter declined calendar events"),
+    include_slack: bool = typer.Option(True, help="Include recent Slack messages"),
+    calendar_blacklist: Optional[List[str]] = typer.Option(
+        None,
+        help="Comma-separated list of keywords to blacklist from calendar events (overrides CALENDAR_EVENT_BLACKLIST)",
+    ),
+    slack_dm: bool = typer.Option(False, help="Send the output as a DM to yourself on Slack"),
+    save_markdown: bool = typer.Option(True, help="Save output to Markdown file"),
+    save_pdf: bool = typer.Option(False, help="Save output to PDF file"),
+    save_path: Optional[Path] = typer.Option(None, help="Custom file path or directory to save the output"),
+    prompt_file: Optional[Path] = typer.Option(None, help="Path to custom prompt file"),
+    model: str = typer.Option("gemini-2.5-pro-preview-05-06", help="Model to use for summarization"),
+    skip_path_checks: bool = typer.Option(False, help="Skip checks for existence of input and output paths"),
+    debug: bool = typer.Option(False, help="Enable debug logging"),
+    quiet: bool = typer.Option(False, help="Suppress output to stdout"),
+) -> None:
+
+    if debug:
+        enable_debug_logging()
+
+    if not skip_path_checks:
+        check_required_directories(journal_dir, extras_dir, save_path)
+
+    prompt_path = prompt_file or Path(__file__).parent / "prompts" / "prepare-event.prompt"
+    if not prompt_path.is_file():
+        typer.echo(f"Error: Default prompt file does not exist: {prompt_path}", err=True)
+        raise typer.Exit(code=1)
+
+    try:
+        tz = pytz.timezone("Europe/Amsterdam")
+        now = datetime.now(tz)
+    if event:
+        start_dt = _parse_event_dt(event)
+        events = _find_upcoming_events(start=start_dt, my_email=my_email, blacklist=calendar_blacklist)
+    else:
+        events = _find_upcoming_events(start=now, my_email=my_email, blacklist=calendar_blacklist)
+
+        if not events:
+            typer.echo("No upcoming events found", err=True)
+            raise typer.Exit(code=1)
+
+        extras_data = extras.load_extras([extras_dir] if extras_dir else [])
+        alias_map = extras.build_alias_map(extras_data)
+        journals_data = (
+            journals.load_journals(
+                journal_dir,
+                journal_days=journal_days,
+                alias_map=alias_map,
+            )
+            if journal_dir
+            else []
+        )
+        emails = gmail.load_emails(now.date(), gmail_labels=gmail_labels)
+        first_dt = datetime.fromisoformat(events[0]["start"])
+        if first_dt.tzinfo is None:
+            first_dt = tz.localize(first_dt)
+        tasks = todoist.load_tasks(first_dt.date(), todoist_project=todoist_project or "")
+        slack_data = slack_loader.load_slack_messages() if include_slack else {}
+        bio = os.getenv("BIO", "")
+
+        summary = summarize_event_preparation(
+            model=model,
+            events=events,
+            journals=journals_data,
+            extras=extras_data,
+            emails=emails,
+            tasks=tasks,
+            slack=slack_data,
+            bio=bio,
+            prompt_path=prompt_path,
+            debug=debug,
+        )
+
+        if not quiet:
+            print(summary)
+
+        if slack_dm:
+            send_slack_dm(summary)
+
+        if save_markdown or save_pdf:
+            first_dt = datetime.fromisoformat(events[0]["start"])
+            if first_dt.tzinfo is None:
+                first_dt = tz.localize(first_dt)
+            filename = first_dt.strftime("%Y-%m-%d_%H%M_event.md")
+            out_path = resolve_output_path(save_path, first_dt.date(), custom_filename=filename)
+
+        if save_markdown:
+            out_path.write_text(summary)
+
+        if save_pdf:
+            convert_markdown_to_pdf(summary, out_path.with_suffix(".pdf"), debug=debug)
+
     except Exception as e:
         handle_exception(e)
 

--- a/vea/prompts/prepare-event.prompt
+++ b/vea/prompts/prepare-event.prompt
@@ -2,34 +2,62 @@ You are Vea, the Chief of Staff supporting a senior leader.
 
 > {bio}
 
-Using the collected data below, produce **last-minute insights** for the upcoming calendar event(s).
-Focus on what will help the leader prepare effectively: related topics, mentions of the event or its participants, open questions, reminders, tasks, and any sensitive context.
+Using the collected data below, produce **last-minute insights** for the upcoming calendar event(s). Focus on what will help the leader prepare effectively: related topics, mentions of the event or its participants, open questions, reminders, tasks, and any sensitive context.
 
 ### Output Format
 For each event, output:
 1. **Event** – Title, start time (include timezone if provided), and list of known attendees if available.
 2. **Insights** – A bullet list (1–3 items) with the most relevant information.
 
-Do not add introductions or closing remarks. Render valid Markdown only.
+**Style Guidelines:**
+- Use a clear, friendly, and concise tone.
+- **Make sure to always output correct and valid Markdown syntax.**
+- When rendering bulleted lists, use exactly one space after the hyphen (e.g., `- Item`).
+- Do not use multiple spaces after a hyphen in lists or checkboxes.
+- Use bold sparingly and only where already instructed.
+- Do **not** include `markdown` as the first word in the output.
+- Do not add introductions or closing remarks.
 
 ---
 
-### Events (JSON)
+### Collected Data:
+
+== Events (JSON) ==
+Each calendar event is a dictionary with the following fields:
+- `summary`: the title of the event
+- `start`: the ISO timestamp or date (if all-day)
+- `end`: the ISO timestamp or date (if all-day)
+- `start_time_zone`: the timezone of the start time
+- `end_time_zone`: the timezone of the end time
+- `attendees`: a list of dictionaries with attendee `name` and `email`
+- `my_status`: the leader's attendance status (e.g., 'accepted', 'tentative')
+- `description`: optional additional notes from the calendar invite
+
 {events}
 
-### Journals (JSON)
+== Journals (JSON) ==
+Journal entries are provided with `filename`, `content`, and `date` (`YYYY_MM_DD`). They follow the Logseq outliner format with indentation representing hierarchy.
+
 {journals}
 
-### Additional Notes (JSON)
+== Additional Notes (JSON) ==
+Additional notes are structured with `filename`, `content`, and `aliases`. They also use the Logseq outliner format. Any `[[...]]` references have been resolved using a canonical alias map.
+
 {extras}
 
-### Emails (JSON)
+== Emails (JSON) ==
+Emails include `subject`, `from`, `date`, and `body`. Only plain-text content is provided. The JSON may contain categories such as `inbox` and `sent`.
+
 {emails}
 
-### Tasks (JSON)
+== Tasks (JSON) ==
+Each task contains `content`, `description`, `due`, `project_id`, and `priority`.
+
 {tasks}
 
-### Slack Messages (JSON)
+== Slack Messages (JSON) ==
+Slack messages are grouped by channel name or DM identifier. Each message includes `user`, `timestamp`, `text`, and optional `replies`.
+
 {slack}
 
 ---

--- a/vea/prompts/prepare-event.prompt
+++ b/vea/prompts/prepare-event.prompt
@@ -1,0 +1,37 @@
+You are Vea, the Chief of Staff supporting a senior leader.
+
+> {bio}
+
+Using the collected data below, produce **last-minute insights** for the upcoming calendar event(s).
+Focus on what will help the leader prepare effectively: related topics, mentions of the event or its participants, open questions, reminders, tasks, and any sensitive context.
+
+### Output Format
+For each event, output:
+1. **Event** – Title, start time (include timezone if provided), and list of known attendees if available.
+2. **Insights** – A bullet list (1–3 items) with the most relevant information.
+
+Do not add introductions or closing remarks. Render valid Markdown only.
+
+---
+
+### Events (JSON)
+{events}
+
+### Journals (JSON)
+{journals}
+
+### Additional Notes (JSON)
+{extras}
+
+### Emails (JSON)
+{emails}
+
+### Tasks (JSON)
+{tasks}
+
+### Slack Messages (JSON)
+{slack}
+
+---
+
+Now generate the insights.

--- a/vea/utils/slack_utils.py
+++ b/vea/utils/slack_utils.py
@@ -1,0 +1,24 @@
+import os
+import logging
+from typing import Optional
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
+logger = logging.getLogger(__name__)
+
+
+def send_slack_dm(message: str, *, token: Optional[str] = None) -> None:
+    """Send a direct message to the authenticated user."""
+    token = token or os.environ.get("SLACK_TOKEN")
+    if not token:
+        logger.warning("SLACK_TOKEN not set; cannot send Slack DM")
+        return
+
+    client = WebClient(token=token)
+    try:
+        user_id = client.auth_test()["user_id"]
+        channel_id = client.conversations_open(users=user_id)["channel"]["id"]
+        client.chat_postMessage(channel=channel_id, text=message)
+        logger.info("Sent Slack DM to user")
+    except SlackApiError as e:
+        logger.warning(f"Failed to send Slack DM: {e.response['error']}")

--- a/vea/utils/summarization.py
+++ b/vea/utils/summarization.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 APP_ROOT = Path(__file__).resolve().parents[2]
 PROMPT_TEMPLATE_PATH = APP_ROOT / "vea" / "prompts" / "daily-default.prompt"
 APP_WEEKLY_PROMPT_PATH = APP_ROOT / "vea/prompts/weekly-default.prompt"
+APP_PREPARE_EVENT_PROMPT_PATH = APP_ROOT / "vea/prompts/prepare-event.prompt"
 
 
 def load_prompt_template(path: Optional[Path] = None) -> str:
@@ -115,6 +116,39 @@ def summarize_weekly(
         journals_contextual=json.dumps(journals_contextual, indent=2, default=str, ensure_ascii=False),
         extras=json.dumps(extras, indent=2, default=str, ensure_ascii=False),
         bio=bio
+    )
+
+    if debug:
+        logger.debug("========== BEGIN PROMPT ==========")
+        logger.debug(prompt)
+        logger.debug("=========== END PROMPT ===========")
+
+    return run_llm_prompt(prompt, model)
+
+
+def summarize_event_preparation(
+    model: str,
+    events: List[dict],
+    journals: List,
+    extras: List,
+    emails: Dict,
+    tasks: List,
+    slack: Optional[Dict[str, List[Dict[str, str]]]] = None,
+    bio: str = "",
+    debug: bool = False,
+    prompt_path: Optional[Path] = None,
+) -> str:
+    """Summarize last-minute insights for upcoming events."""
+
+    template = load_prompt_template(prompt_path or APP_PREPARE_EVENT_PROMPT_PATH)
+    prompt = template.format(
+        bio=bio,
+        events=json.dumps(events, indent=2, default=str, ensure_ascii=False),
+        journals=json.dumps(journals, indent=2, default=str, ensure_ascii=False),
+        extras=json.dumps(extras, indent=2, default=str, ensure_ascii=False),
+        emails=json.dumps(emails, indent=2, default=str, ensure_ascii=False),
+        tasks=json.dumps(tasks, indent=2, default=str, ensure_ascii=False),
+        slack=json.dumps(slack, indent=2, default=str, ensure_ascii=False) if slack else "",
     )
 
     if debug:


### PR DESCRIPTION
## Summary
- add prepare-event.prompt with instructions for last-minute insights
- implement `summarize_event_preparation` in summarization utils
- add Slack DM helper
- introduce new `prepare-event` CLI command
- add todoist-project flag to prepare-event

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68400a3cf360832c8dad6254e9899538