### PR TITLE
Handle calendar events without summary

### DIFF
--- a/tests/test_prepare_event.py
+++ b/tests/test_prepare_event.py
@@ -108,3 +108,21 @@ def test_find_upcoming_events_filters(monkeypatch):
 
     assert len(result) == 1
     assert result[0]["summary"] == "Real Meeting"
+
+
+def test_find_upcoming_events_handles_none_summary(monkeypatch):
+    events = [
+        {"summary": None, "start": "2025-05-01T10:00:00", "end": "2025-05-01T11:00:00"},
+        {"summary": "Valid Meeting", "start": "2025-05-01T11:00:00", "end": "2025-05-01T12:00:00"},
+    ]
+
+    def dummy_load_events(*args, **kwargs):
+        return events
+
+    monkeypatch.setattr(cli.gcal, "load_events", dummy_load_events)
+
+    start = datetime(2025, 5, 1, 9, 0)
+    result = cli._find_upcoming_events(start=start, my_email=None, blacklist=None)
+
+    assert len(result) == 1
+    assert result[0]["summary"] == "Valid Meeting"

--- a/vea/utils/event_utils.py
+++ b/vea/utils/event_utils.py
@@ -66,7 +66,7 @@ def find_upcoming_events(
             e
             for e in timed
             if current <= _dt(e) <= end_limit
-            and e.get("summary", "").strip()
+            and (e.get("summary") or "").strip()
             and not _matches_blacklist(e)
         ]
 


### PR DESCRIPTION
## Summary
- fix filtering of events that have `summary=None`
- test that events with `None` summaries are ignored

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a6745ba0832c83a1ec3c9f9fff19