### PR TITLE
Include today's open tasks in check-for-tasks

### DIFF
--- a/vea/cli/check_for_tasks.py
+++ b/vea/cli/check_for_tasks.py
@@ -66,7 +66,7 @@ def check_for_tasks(
             lookback_days=todoist_lookback_days,
             todoist_project=todoist_project or "",
         )
-        future_tasks = todoist.load_future_tasks(todoist_project=todoist_project or "")
+        open_tasks = todoist.load_open_tasks(todoist_project=todoist_project or "")
         bio = os.getenv("BIO", "")
 
         summary = summarize_check_for_tasks(
@@ -74,7 +74,7 @@ def check_for_tasks(
             journals=journals_data,
             emails=emails,
             completed_tasks=completed_tasks,
-            future_tasks=future_tasks,
+            open_tasks=open_tasks,
             slack=slack_data,
             bio=bio,
             prompt_path=prompt_path,

--- a/vea/prompts/check-for-tasks-default.prompt
+++ b/vea/prompts/check-for-tasks-default.prompt
@@ -2,7 +2,7 @@ You are Vea, the Chief of Staff supporting a senior leader.
 
 > {bio}
 
-Analyze the collected data to find open tasks, follow-ups, or to-dos that may have been mentioned but were never completed or captured as Todoist tasks. Look for anything implied in journals, emails, or Slack messages that does not appear in the completed or future Todoist task lists.
+Analyze the collected data to find open tasks, follow-ups, or to-dos that may have been mentioned but were never completed or captured as Todoist tasks. Look for anything implied in journals, emails, or Slack messages that does not appear in the completed or open Todoist task lists.
 
 Return a concise bullet list of potential tasks the leader might have forgotten or not yet tracked.
 
@@ -22,8 +22,8 @@ Return a concise bullet list of potential tasks the leader might have forgotten 
 == Completed Todoist Tasks (JSON) ==
 {completed_tasks}
 
-== Future Todoist Tasks (JSON) ==
-{future_tasks}
+== Open Todoist Tasks (JSON) ==
+{open_tasks}
 
 ---
 

--- a/vea/utils/summarization.py
+++ b/vea/utils/summarization.py
@@ -164,7 +164,7 @@ def summarize_check_for_tasks(
     journals: List,
     emails: Dict,
     completed_tasks: List,
-    future_tasks: List,
+    open_tasks: List,
     slack: Optional[Dict[str, List[Dict[str, str]]]] = None,
     bio: str = "",
     quiet: bool = False,
@@ -179,7 +179,7 @@ def summarize_check_for_tasks(
         journals=json.dumps(journals, indent=2, default=str, ensure_ascii=False),
         emails=json.dumps(emails, indent=2, default=str, ensure_ascii=False),
         completed_tasks=json.dumps(completed_tasks, indent=2, default=str, ensure_ascii=False),
-        future_tasks=json.dumps(future_tasks, indent=2, default=str, ensure_ascii=False),
+        open_tasks=json.dumps(open_tasks, indent=2, default=str, ensure_ascii=False),
         slack=json.dumps(slack, indent=2, default=str, ensure_ascii=False) if slack else "",
     )
 


### PR DESCRIPTION
## Summary
- fetch open Todoist tasks due today or later
- include these tasks when generating task summary
- adjust default prompt for open task context

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417371e6f8832cb540f315e463ef49