### PR TITLE
Add `now` and `next` keywords for prepare-event

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,14 +119,14 @@ Run `vea weekly --help` to see all options. Key options include:
 
 ### Prepare for an event
 
-Use `vea prepare-event` to get a quick briefing before a meeting. The command collects emails, tasks, notes and Slack messages around the event time and summarizes them with your LLM of choice. If you don't specify `--event`, the next upcoming calendar entry is used.
+Use `vea prepare-event` to get a quick briefing before a meeting. The command collects emails, tasks, notes and Slack messages around the event time and summarizes them with your LLM of choice. By default it looks at the next calendar entry, but you can target a specific moment with the `--event` option.
 
 ```bash
 vea prepare-event --lookahead-minutes 30 --slack-dm
 ```
 
 Key options include:
-- `--event` – Event start time like `2025-05-28 14:00`
+- `--event` – Moment to prepare for. Use a start time like `2025-05-28 14:00`, `now` for the current meeting, or `next` for the next one
 - `--lookahead-minutes` – How far ahead to search for the next event
 - `--journal-dir` – Directory with Markdown journal files
 - `--journal-days` – Number of past journal days to include (default: 21)

--- a/vea/cli/__init__.py
+++ b/vea/cli/__init__.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv, find_dotenv
 from ..loaders import gcal, gmail, journals, extras, todoist, slack as slack_loader
 
 from . import auth, daily, weekly, prepare_event, check_for_tasks
-from .utils import _find_upcoming_events
+from .utils import _find_upcoming_events, _find_current_events
 
 app = typer.Typer(help="Vea: Generate a personalized daily briefing or weekly summary.")
 
@@ -33,4 +33,5 @@ __all__ = [
     "todoist",
     "slack_loader",
     "_find_upcoming_events",
+    "_find_current_events",
 ]

--- a/vea/cli/utils.py
+++ b/vea/cli/utils.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 from typing import List, Optional
 
-from ..utils.event_utils import find_upcoming_events
+from ..utils.event_utils import find_upcoming_events, find_current_events
 
 
 def _find_upcoming_events(
@@ -24,4 +24,17 @@ def _find_upcoming_events(
         lookahead_minutes=lookahead_minutes,
     )
 
-__all__ = ["_find_upcoming_events"]
+
+def _find_current_events(
+    *,
+    my_email: Optional[str],
+    blacklist: Optional[List[str]],
+) -> List[dict]:
+    """Wrapper for :func:`find_current_events` to allow easier testing."""
+    if blacklist is None:
+        env_bl = os.getenv("CALENDAR_EVENT_BLACKLIST", "")
+        blacklist = [b.strip() for b in env_bl.split(",") if b.strip()]
+
+    return find_current_events(my_email=my_email, blacklist=blacklist)
+
+__all__ = ["_find_upcoming_events", "_find_current_events"]


### PR DESCRIPTION
## Summary
- enable `prepare-event` to accept `now` or `next` for `--event`
- document the `--event` option with the new `next` keyword

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68456277f6f8832c99b412065bac3219