### PR TITLE
Improve relevance filtering pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Below is a complete list of options for `vea daily` (run `vea daily --help` to s
 - `--save-path` – Custom file path or directory for the output
 - `--prompt-file` – Path to a custom prompt file (default: `/prompts/daily-default.prompt`)
 - `--model` – LLM to use for summarization (e.g. `o4-mini`, `claude-3-7-sonnet-latest`, `gemini-2.5-pro-preview-05-06`)
+- `--token-budget` – Maximum tokens to include after filtering (default: 10000)
+- `--budget-scope` – `global` to rank all documents together or `group` per source (default: global)
+- `--focus-topics-override` – Custom focus topics for debugging the filter
 - `--skip-path-checks` – Skip validation of input/output paths
 - `--debug` – Enable debug logging
 - `--quiet` – Suppress printing the summary to stdout
@@ -116,6 +119,7 @@ Run `vea weekly --help` to see all options. Key options include:
 - `--save-pdf` – Save the summary as a PDF
 - `--save-path` – Custom output directory or file path
 - `--prompt-file` – Path to a custom prompt file (default: `/prompts/weekly-default.prompt`)
+- `--token-budget` – Maximum tokens for the summarized context (default: 10000)
 
 ### Prepare for an event
 
@@ -132,6 +136,8 @@ Key options include:
 - `--journal-days` – Number of past journal days to include (default: 21)
 - `--slack-days` – Number of past days of Slack messages to load (default: 5)
 - `--slack-dm` – Send the output as a Slack DM to yourself
+- `--token-budget` – Maximum tokens for filtering documents (default: 10000)
+- `--focus-topics-override` – Override the automatically detected focus topics
 
 ### Check for forgotten tasks
 
@@ -142,6 +148,9 @@ vea check-for-tasks --journal-dir ~/Logseq/journals --todoist-lookback-days 10
 ```
 
 This command detects untracked or unfinished to-dos based on your recent activity. Use `--todoist-lookback-days` to set how far back to include completed Todoist tasks (default: 7 days).
+
+Key options include:
+- `--token-budget` – Maximum tokens for filtering documents (default: 10000)
 
 ### AI Summary Engine
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
   "anthropic>=0.1.3",
   "google-generativeai>=0.8.5",
   "weasyprint>=65.1",
-  "markdown>=3.8"
+  "markdown>=3.8",
+  "sumy>=0.11"
 ]
 
 [project.scripts]

--- a/tests/test_check_for_tasks_filtering.py
+++ b/tests/test_check_for_tasks_filtering.py
@@ -1,0 +1,96 @@
+import sys
+from types import SimpleNamespace
+from datetime import datetime
+
+class _DummyTyper:
+    def __init__(self, *a, **k):
+        pass
+    def command(self, *a, **k):
+        def dec(f):
+            return f
+        return dec
+
+def _dummy_option(*a, **k):
+    return None
+
+sys.modules.setdefault(
+    "typer",
+    SimpleNamespace(
+        Typer=_DummyTyper,
+        Option=_dummy_option,
+        Argument=_dummy_option,
+        echo=lambda *a, **k: None,
+        Exit=Exception,
+    ),
+)
+
+sys.modules.setdefault(
+    "dotenv",
+    SimpleNamespace(load_dotenv=lambda *a, **k: None, find_dotenv=lambda *a, **k: ""),
+)
+
+# Stub heavy deps
+sys.modules.setdefault("todoist_api_python.api", SimpleNamespace(TodoistAPI=object))
+sys.modules.setdefault("slack_sdk", SimpleNamespace(WebClient=object))
+sys.modules.setdefault("slack_sdk.errors", SimpleNamespace(SlackApiError=Exception))
+sys.modules.setdefault("google.oauth2.credentials", SimpleNamespace(Credentials=object))
+sys.modules.setdefault("googleapiclient.discovery", SimpleNamespace(build=lambda *a, **k: None))
+sys.modules.setdefault("google_auth_oauthlib.flow", SimpleNamespace(InstalledAppFlow=None))
+sys.modules.setdefault("openai", SimpleNamespace())
+sys.modules.setdefault("anthropic", SimpleNamespace())
+_google_pkg = SimpleNamespace(generativeai=SimpleNamespace(GenerativeModel=lambda *a, **k: None))
+sys.modules.setdefault("google", _google_pkg)
+sys.modules.setdefault("google.generativeai", _google_pkg.generativeai)
+sys.modules.setdefault("markdown", SimpleNamespace(markdown=lambda *a, **k: ""))
+sys.modules.setdefault("weasyprint", SimpleNamespace(HTML=lambda *a, **k: None, CSS=lambda *a, **k: None))
+
+import vea.cli.check_for_tasks as cft
+
+
+def test_check_for_tasks_filtering(monkeypatch):
+    monkeypatch.setattr(cft.extras, "load_extras", lambda paths: [{"filename": "ex1", "content": "alpha note", "aliases": ["Alpha"]}])
+    monkeypatch.setattr(cft.extras, "build_alias_map", lambda extras: {"alpha": "ex1"})
+    monkeypatch.setattr(
+        cft.journals,
+        "load_journals",
+        lambda *a, **k: [
+            {"filename": "j1", "content": "remember to ping Alpha", "date": datetime(2025,5,1).date()},
+            {"filename": "j2", "content": "random note", "date": datetime(2025,5,1).date()},
+        ],
+    )
+    monkeypatch.setattr(
+        cft.gmail,
+        "load_emails",
+        lambda *a, **k: {"inbox": [{"subject": "hi", "body": "follow up with Alpha", "from": "alice"}]},
+    )
+    monkeypatch.setattr(
+        cft.slack_loader,
+        "load_slack_messages",
+        lambda *a, **k: {"general": [{"user": "bob", "timestamp": "", "text": "- [ ] call Alpha", "replies": []}]},
+    )
+    monkeypatch.setattr(cft.todoist, "load_completed_tasks", lambda *a, **k: [])
+    monkeypatch.setattr(cft.todoist, "load_open_tasks", lambda *a, **k: [])
+
+    captured = {}
+
+    def fake_summary(**kwargs):
+        captured.update(kwargs)
+        return "SUM"
+
+    monkeypatch.setattr(cft, "summarize_check_for_tasks", fake_summary)
+    monkeypatch.setattr(cft, "summarize_text", lambda txt, max_sentences=2: "SUM")
+    monkeypatch.setattr(cft, "estimate_tokens", lambda txt: 5)
+
+    from pathlib import Path
+    cft.check_for_tasks(
+        journal_dir=Path("."),
+        extras_dir=Path("."),
+        token_budget=25,
+        include_slack=True,
+        skip_path_checks=True,
+    )
+
+    assert captured["journals"][0]["filename"] == "j1"
+    assert list(captured["emails"].values())[0][0]["body"] == "SUM"
+    assert list(captured["slack"].values())[0][0]["text"] == "SUM"
+

--- a/tests/test_daily_filtering.py
+++ b/tests/test_daily_filtering.py
@@ -1,0 +1,132 @@
+import sys
+from types import SimpleNamespace
+from datetime import datetime
+
+# Minimal typer stub
+class _DummyTyper:
+    def __init__(self, *a, **k):
+        pass
+    def command(self, *a, **k):
+        def dec(f):
+            return f
+        return dec
+
+def _dummy_option(*a, **k):
+    return None
+
+sys.modules.setdefault(
+    "typer",
+    SimpleNamespace(
+        Typer=_DummyTyper,
+        Option=_dummy_option,
+        Argument=_dummy_option,
+        echo=lambda *a, **k: None,
+        Exit=Exception,
+    ),
+)
+
+sys.modules.setdefault(
+    "dotenv",
+    SimpleNamespace(load_dotenv=lambda *a, **k: None, find_dotenv=lambda *a, **k: ""),
+)
+
+# Stub heavy deps
+sys.modules.setdefault("todoist_api_python.api", SimpleNamespace(TodoistAPI=object))
+sys.modules.setdefault("slack_sdk", SimpleNamespace(WebClient=object))
+sys.modules.setdefault("slack_sdk.errors", SimpleNamespace(SlackApiError=Exception))
+sys.modules.setdefault("google.oauth2.credentials", SimpleNamespace(Credentials=object))
+sys.modules.setdefault("googleapiclient.discovery", SimpleNamespace(build=lambda *a, **k: None))
+sys.modules.setdefault("google_auth_oauthlib.flow", SimpleNamespace(InstalledAppFlow=None))
+sys.modules.setdefault("openai", SimpleNamespace())
+sys.modules.setdefault("anthropic", SimpleNamespace())
+_google_pkg = SimpleNamespace(generativeai=SimpleNamespace(GenerativeModel=lambda *a, **k: None))
+sys.modules.setdefault("google", _google_pkg)
+sys.modules.setdefault("google.generativeai", _google_pkg.generativeai)
+sys.modules.setdefault("markdown", SimpleNamespace(markdown=lambda *a, **k: ""))
+sys.modules.setdefault("weasyprint", SimpleNamespace(HTML=lambda *a, **k: None, CSS=lambda *a, **k: None))
+
+import vea.cli.daily as daily
+
+
+def test_daily_generate_global_budget(monkeypatch):
+    # Patch loader functions to return sample data
+    monkeypatch.setattr(daily.extras, "load_extras", lambda paths: [{"filename": "ex1", "content": "alpha note", "aliases": ["Alpha"]}])
+    monkeypatch.setattr(daily.extras, "build_alias_map", lambda extras: {"alpha": "ex1"})
+    monkeypatch.setattr(daily.journals, "load_journals", lambda *a, **k: [{"filename": "j1", "content": "alpha journal", "date": datetime(2025,4,30).date()}])
+    monkeypatch.setattr(daily.gcal, "load_events", lambda *a, **k: [{"summary": "Alpha Meeting", "description": "discuss", "attendees": [{"name": "Alice", "email": "alice@example.com"}]}])
+    monkeypatch.setattr(daily.todoist, "load_tasks", lambda *a, **k: [{"content": "Finish alpha", "description": ""}])
+    monkeypatch.setattr(daily.gmail, "load_emails", lambda *a, **k: {"inbox": [{"subject": "hello", "from": "alice", "date": "", "body": "alpha"}]})
+    monkeypatch.setattr(daily.slack_loader, "load_slack_messages", lambda *a, **k: {"general": [{"user": "bob", "timestamp": "", "text": "alpha"}]})
+
+    monkeypatch.setattr(daily, "parse_date", lambda x: datetime(2025,5,1).date())
+
+    calls = []
+
+    def fake_run_pipeline(docs, topics, **kwargs):
+        calls.append({"docs": docs, "topics": topics})
+        out = docs[:1]
+        for d in out:
+            d.setdefault("token_count", 5)
+        return {"documents": out, "total_tokens": 5}
+
+    monkeypatch.setattr(daily, "run_pipeline", fake_run_pipeline)
+
+    captured = {}
+    def fake_summary(**kwargs):
+        captured.update({"journals": kwargs["journals"], "extras": kwargs["extras"], "emails": kwargs["emails"], "slack": kwargs["slack"]})
+        return "SUM"
+
+    monkeypatch.setattr(daily, "summarize_daily", fake_summary)
+
+    from pathlib import Path
+    daily.generate(
+        date="2025-05-01",
+        include_slack=True,
+        skip_path_checks=True,
+        token_budget=50,
+        budget_scope="global",
+        journal_dir=Path("."),
+    )
+
+    assert len(calls) == 1
+    assert any("Alpha Meeting" in t for t in calls[0]["topics"])
+    assert captured["journals"][0]["filename"] == "j1"
+
+
+def test_daily_generate_group_budget(monkeypatch):
+    monkeypatch.setattr(daily.extras, "load_extras", lambda paths: [{"filename": "ex1", "content": "alpha note", "aliases": ["Alpha"]}])
+    monkeypatch.setattr(daily.extras, "build_alias_map", lambda extras: {"alpha": "ex1"})
+    monkeypatch.setattr(daily.journals, "load_journals", lambda *a, **k: [{"filename": "j1", "content": "alpha journal", "date": datetime(2025,4,30).date()}])
+    monkeypatch.setattr(daily.gcal, "load_events", lambda *a, **k: [{"summary": "Alpha Meeting"}])
+    monkeypatch.setattr(daily.todoist, "load_tasks", lambda *a, **k: [])
+    monkeypatch.setattr(daily.gmail, "load_emails", lambda *a, **k: {"inbox": [{"subject": "hello", "body": "alpha"}]})
+    monkeypatch.setattr(daily.slack_loader, "load_slack_messages", lambda *a, **k: {})
+    monkeypatch.setattr(daily, "parse_date", lambda x: datetime(2025,5,1).date())
+
+    calls = []
+
+    def fake_run_pipeline(docs, topics, **kwargs):
+        calls.append((docs, topics))
+        out = docs[:1]
+        for d in out:
+            d.setdefault("token_count", 5)
+        return {"documents": out, "total_tokens": 5}
+
+    monkeypatch.setattr(daily, "run_pipeline", fake_run_pipeline)
+
+    def fake_summary(**kwargs):
+        return "SUM"
+
+    monkeypatch.setattr(daily, "summarize_daily", fake_summary)
+
+    from pathlib import Path
+    daily.generate(
+        date="2025-05-01",
+        include_slack=False,
+        skip_path_checks=True,
+        token_budget=50,
+        budget_scope="group",
+        journal_dir=Path("."),
+    )
+
+    assert len(calls) == 3  # journal, extra, email; slack skipped

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1,0 +1,135 @@
+import vea.utils.filtering as filt
+
+
+def test_filter_documents_tfidf_returns_most_relevant():
+    docs = [
+        "Discuss project Alpha next week",
+        "Grocery list: milk, eggs, bread",
+        "Meeting notes about project Beta",
+    ]
+    topics = ["project Alpha kickoff"]
+
+    result = filt.filter_documents(docs, topics, top_n=1)
+    assert result == [docs[0]]
+
+
+def test_filter_documents_keyword_threshold():
+    docs = [
+        "Remember to buy apples",
+        "Schedule meeting with team",
+    ]
+    topics = ["apples", "oranges"]
+
+    result = filt.filter_documents(docs, topics, ranker=filt.KeywordRanker(), threshold=0.1)
+    assert result == [docs[0]]
+
+
+def test_pipeline_limits_and_ranks():
+    docs = [
+        {"id": "1", "type": "journal", "content": "Alpha project update"},
+        {"id": "2", "type": "note", "content": "Random thoughts"},
+        {"id": "3", "type": "email", "content": "Alpha meeting tomorrow"},
+    ]
+    topics = ["Alpha meeting"]
+
+    pipe = filt.RelevanceFilterPipeline(max_documents=2)
+    result = pipe.filter(docs, topics)
+
+    assert len(result["documents"]) == 2
+    assert result["documents"][0]["id"] == "3"  # email mentioning meeting should rank highest
+
+
+def test_pipeline_with_custom_strategy():
+    docs = [
+        {"id": "1", "type": "note", "content": "Buy milk"},
+        {"id": "2", "type": "journal", "content": "Meeting about Beta"},
+    ]
+    topics = ["milk"]
+
+    pipe = filt.RelevanceFilterPipeline(strategies=[filt.KeywordMatchStrategy()])
+    result = pipe.filter(docs, topics)
+
+    assert result["documents"][0]["id"] == "1"
+
+
+def test_run_pipeline_helper():
+    docs = [
+        {"id": "1", "type": "note", "content": "Discuss Alpha"},
+        {"id": "2", "type": "note", "content": "Discuss Beta"},
+    ]
+    topics = ["Alpha"]
+
+    result = filt.run_pipeline(docs, topics, max_documents=1)
+
+    assert result["documents"][0]["id"] == "1"
+
+
+def test_pipeline_respects_token_budget():
+    docs = [
+        {"id": "1", "type": "note", "content": "Alpha project " * 20},
+        {"id": "2", "type": "note", "content": "Beta project " * 20},
+    ]
+    topics = ["Alpha project"]
+
+    result = filt.run_pipeline(docs, topics, token_budget=80)
+
+    assert result["total_tokens"] <= 80
+    assert len(result["documents"]) == 1
+    assert result["documents"][0]["id"] == "1"
+
+
+def test_return_scores_and_weighting():
+    docs = [
+        {"id": "1", "type": "note", "content": "Alpha Beta"},
+    ]
+    topics = ["Alpha"]
+
+    pipe = filt.RelevanceFilterPipeline(
+        strategies=[(filt.TFIDFStrategy(preprocess=False), 0.7), (filt.KeywordMatchStrategy(preprocess=False), 0.3)],
+        max_documents=1,
+    )
+    result = pipe.filter(docs, topics, return_scores=True)
+
+    doc = result["documents"][0]
+    tfidf = doc["strategy_scores"]["TFIDFStrategy"]
+    kw = doc["strategy_scores"]["KeywordMatchStrategy"]
+    expected = tfidf * 0.7 + kw * 0.3
+    assert abs(doc["combined_score"] - expected) < 1e-6
+
+
+class CountStrategy(filt.RelevanceStrategy):
+    def score(self, doc: str, topics: list[str]) -> float:
+        doc_tokens = set(self._prep(doc))
+        topic_tokens = set(self._prep(" ".join(topics)))
+        return len(doc_tokens & topic_tokens)
+
+
+def test_score_normalization_and_weighting():
+    docs = [{"id": "1", "type": "note", "content": "alpha beta gamma"}]
+    topics = ["alpha beta"]
+
+    pipe = filt.RelevanceFilterPipeline(
+        strategies=[(CountStrategy(preprocess=False), 0.5), (filt.KeywordMatchStrategy(preprocess=False), 0.5)],
+        max_documents=1,
+    )
+    result = pipe.filter(docs, topics, return_scores=True)
+    doc = result["documents"][0]
+    count_sc = doc["strategy_scores"]["CountStrategy"]
+    kw_sc = doc["strategy_scores"]["KeywordMatchStrategy"]
+    expected = count_sc * 0.5 + kw_sc * 0.5
+    assert count_sc == 1.0  # normalized from raw count 2
+    assert abs(doc["combined_score"] - expected) < 1e-6
+
+
+def test_token_budget_skips_large_doc():
+    docs = [
+        {"id": "1", "type": "note", "content": "big " * 100},
+        {"id": "2", "type": "note", "content": "small relevant"},
+    ]
+    topics = ["relevant"]
+
+    result = filt.run_pipeline(docs, topics, token_budget=20)
+
+    assert len(result["documents"]) == 1
+    assert result["documents"][0]["id"] == "2"
+

--- a/tests/test_prepare_event_filtering.py
+++ b/tests/test_prepare_event_filtering.py
@@ -1,0 +1,98 @@
+import sys
+from types import SimpleNamespace
+from datetime import datetime
+
+class _DummyTyper:
+    def __init__(self, *a, **k):
+        pass
+    def command(self, *a, **k):
+        def dec(f):
+            return f
+        return dec
+
+def _dummy_option(*a, **k):
+    return None
+
+sys.modules.setdefault(
+    "typer",
+    SimpleNamespace(
+        Typer=_DummyTyper,
+        Option=_dummy_option,
+        Argument=_dummy_option,
+        echo=lambda *a, **k: None,
+        Exit=Exception,
+    ),
+)
+
+sys.modules.setdefault(
+    "dotenv",
+    SimpleNamespace(load_dotenv=lambda *a, **k: None, find_dotenv=lambda *a, **k: ""),
+)
+
+# Stub heavy deps
+sys.modules.setdefault("todoist_api_python.api", SimpleNamespace(TodoistAPI=object))
+sys.modules.setdefault("slack_sdk", SimpleNamespace(WebClient=object))
+sys.modules.setdefault("slack_sdk.errors", SimpleNamespace(SlackApiError=Exception))
+sys.modules.setdefault("google.oauth2.credentials", SimpleNamespace(Credentials=object))
+sys.modules.setdefault("googleapiclient.discovery", SimpleNamespace(build=lambda *a, **k: None))
+sys.modules.setdefault("google_auth_oauthlib.flow", SimpleNamespace(InstalledAppFlow=None))
+sys.modules.setdefault("openai", SimpleNamespace())
+sys.modules.setdefault("anthropic", SimpleNamespace())
+_google_pkg = SimpleNamespace(generativeai=SimpleNamespace(GenerativeModel=lambda *a, **k: None))
+sys.modules.setdefault("google", _google_pkg)
+sys.modules.setdefault("google.generativeai", _google_pkg.generativeai)
+sys.modules.setdefault("markdown", SimpleNamespace(markdown=lambda *a, **k: ""))
+sys.modules.setdefault("weasyprint", SimpleNamespace(HTML=lambda *a, **k: None, CSS=lambda *a, **k: None))
+
+import vea.cli.prepare_event as pe
+
+
+def test_prepare_event_filters(monkeypatch):
+    monkeypatch.setattr(pe.extras, "load_extras", lambda paths: [{"filename": "ex1", "content": "alpha note", "aliases": ["Alpha"]}])
+    monkeypatch.setattr(pe.extras, "build_alias_map", lambda extras: {"alpha": "ex1"})
+    monkeypatch.setattr(pe.journals, "load_journals", lambda *a, **k: [{"filename": "j1", "content": "alpha journal", "date": datetime(2025,4,30).date()}])
+    monkeypatch.setattr(
+        pe, "find_upcoming_events", lambda *a, **k: [{"summary": "Alpha Meeting", "description": "discuss", "attendees": [{"name": "Alice", "email": "alice@example.com"}], "start": "2025-05-01T10:00:00"}]
+    )
+    monkeypatch.setattr(pe.gmail, "load_emails", lambda *a, **k: {"inbox": [{"subject": "hello", "body": "alpha"}]})
+    monkeypatch.setattr(pe.todoist, "load_tasks", lambda *a, **k: [])
+    monkeypatch.setattr(pe.slack_loader, "load_slack_messages", lambda *a, **k: {"general": [{"user": "bob", "timestamp": "", "text": "alpha"}]})
+
+    calls = []
+
+    def fake_run_pipeline(docs, topics, **kwargs):
+        calls.append({"docs": docs, "topics": topics})
+        out = docs[:1]
+        for d in out:
+            d.setdefault("token_count", 5)
+        return {"documents": out, "total_tokens": 5}
+
+    monkeypatch.setattr(pe, "run_pipeline", fake_run_pipeline)
+
+    captured = {}
+
+    def fake_summary(**kwargs):
+        captured.update({
+            "journals": kwargs["journals"],
+            "extras": kwargs["extras"],
+            "emails": kwargs["emails"],
+            "slack": kwargs["slack"],
+        })
+        return "SUM"
+
+    monkeypatch.setattr(pe, "summarize_event_preparation", fake_summary)
+
+    from pathlib import Path
+    pe.prepare_event(
+        event="next",
+        include_slack=True,
+        skip_path_checks=True,
+        token_budget=50,
+        journal_dir=Path("."),
+    )
+
+    assert len(calls) == 4
+    assert any("Alpha Meeting" in t for t in calls[0]["topics"])
+    assert any("alice@example.com" in t or "Alice" in t for t in calls[0]["topics"])
+    assert captured["journals"][0]["filename"] == "j1"
+

--- a/tests/test_weekly_compression.py
+++ b/tests/test_weekly_compression.py
@@ -1,0 +1,83 @@
+import sys
+from types import SimpleNamespace
+from datetime import datetime
+
+class _DummyTyper:
+    def __init__(self, *a, **k):
+        pass
+    def command(self, *a, **k):
+        def dec(f):
+            return f
+        return dec
+
+def _dummy_option(*a, **k):
+    return None
+
+sys.modules.setdefault(
+    "typer",
+    SimpleNamespace(
+        Typer=_DummyTyper,
+        Option=_dummy_option,
+        Argument=_dummy_option,
+        echo=lambda *a, **k: None,
+        Exit=Exception,
+    ),
+)
+
+sys.modules.setdefault(
+    "dotenv",
+    SimpleNamespace(load_dotenv=lambda *a, **k: None, find_dotenv=lambda *a, **k: ""),
+)
+
+sys.modules.setdefault("todoist_api_python.api", SimpleNamespace(TodoistAPI=object))
+sys.modules.setdefault("slack_sdk", SimpleNamespace(WebClient=object))
+sys.modules.setdefault("slack_sdk.errors", SimpleNamespace(SlackApiError=Exception))
+sys.modules.setdefault("google.oauth2.credentials", SimpleNamespace(Credentials=object))
+sys.modules.setdefault("googleapiclient.discovery", SimpleNamespace(build=lambda *a, **k: None))
+sys.modules.setdefault("google_auth_oauthlib.flow", SimpleNamespace(InstalledAppFlow=None))
+sys.modules.setdefault("openai", SimpleNamespace())
+sys.modules.setdefault("anthropic", SimpleNamespace())
+_google_pkg = SimpleNamespace(generativeai=SimpleNamespace(GenerativeModel=lambda *a, **k: None))
+sys.modules.setdefault("google", _google_pkg)
+sys.modules.setdefault("google.generativeai", _google_pkg.generativeai)
+sys.modules.setdefault("markdown", SimpleNamespace(markdown=lambda *a, **k: ""))
+sys.modules.setdefault("weasyprint", SimpleNamespace(HTML=lambda *a, **k: None, CSS=lambda *a, **k: None))
+
+import vea.cli.weekly as weekly
+
+
+def test_weekly_compression(monkeypatch):
+    monkeypatch.setattr(weekly, "load_extras", lambda paths: [{"filename": "ex1", "content": "alpha note", "aliases": ["Alpha"]}])
+    monkeypatch.setattr(weekly.extras, "build_alias_map", lambda extras: {"alpha": "ex1"})
+    monkeypatch.setattr(
+        weekly, "load_journals", lambda *a, **k: [
+            {"filename": "j1", "content": "alpha journal" * 20, "date": datetime(2025,5,3).date()},
+            {"filename": "j2", "content": "beta journal" * 20, "date": datetime(2025,4,20).date()},
+        ]
+    )
+    monkeypatch.setattr(weekly, "parse_week_input", lambda w: (datetime(2025,5,1).date(), datetime(2025,5,7).date()))
+
+    calls = []
+    def fake_summary(**kwargs):
+        calls.append(kwargs)
+        return "SUM"
+    monkeypatch.setattr(weekly, "summarize_weekly", fake_summary)
+
+    s_calls = []
+    monkeypatch.setattr(weekly, "summarize_text", lambda txt, max_sentences=2: s_calls.append(txt) or "SUM")
+    monkeypatch.setattr(weekly, "estimate_tokens", lambda txt: 50)
+
+    from pathlib import Path
+    weekly.generate_weekly_summary(
+        week="2025-W18",
+        skip_path_checks=True,
+        token_budget=80,
+        journal_dir=Path("."),
+    )
+
+    assert len(s_calls) >= 1
+    assert len(calls) == 1
+    assert len(calls[0]["journals_in_week"]) == 1
+    journal = calls[0]["journals_in_week"][0]
+    assert journal["filename"] == "j1"
+    assert journal.get("token_count") == 50

--- a/vea/cli/check_for_tasks.py
+++ b/vea/cli/check_for_tasks.py
@@ -1,16 +1,27 @@
 import os
+import logging
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
 import typer
 
-from ..loaders import gmail, journals, slack as slack_loader, todoist
+from ..loaders import gmail, journals, slack as slack_loader, todoist, extras
 from ..utils.output_utils import resolve_output_path
 from ..utils.error_utils import enable_debug_logging, handle_exception
 from ..utils.summarization import summarize_check_for_tasks
 from ..utils.pdf_utils import convert_markdown_to_pdf
 from ..utils.generic_utils import check_required_directories
+from ..utils.text_utils import estimate_tokens, summarize_text
+
+logger = logging.getLogger(__name__)
+
+_TOKEN_RE = re.compile(r"\b\w+\b")
+_TASK_PATTERNS = [
+    re.compile(p, re.I)
+    for p in [r"- \[ \]", r"TODO", r"follow up", r"remember to", r"check with"]
+]
 
 app = typer.Typer()
 
@@ -19,6 +30,7 @@ app = typer.Typer()
 def check_for_tasks(
     journal_dir: Optional[Path] = typer.Option(None, help="Directory with Markdown journal files"),
     journal_days: int = typer.Option(7, help="Number of past days of journals to include"),
+    extras_dir: Optional[Path] = typer.Option(None, help="Directory with additional Markdown notes"),
     gmail_labels: Optional[List[str]] = typer.Option(None, help="List of additional Gmail labels to fetch emails from"),
     todoist_project: Optional[str] = typer.Option(None, help="Name of the Todoist project to filter tasks by"),
     todoist_lookback_days: int = typer.Option(7, help="Number of days to look back for completed Todoist tasks"),
@@ -34,6 +46,7 @@ def check_for_tasks(
     model: str = typer.Option(
         "gemini-2.5-pro-preview-06-05", help="Model to use for summarization (OpenAI, Google Gemini, or Anthropic)"
     ),
+    token_budget: int = typer.Option(10000, help="Token budget for summarized context"),
     skip_path_checks: bool = typer.Option(False, help="Skip checks for existence of input and output paths"),
     debug: bool = typer.Option(False, help="Enable debug logging"),
     quiet: bool = typer.Option(False, help="Suppress output to stdout"),
@@ -43,7 +56,7 @@ def check_for_tasks(
         enable_debug_logging()
 
     if not skip_path_checks:
-        check_required_directories(journal_dir, None, save_path)
+        check_required_directories(journal_dir, extras_dir, save_path)
 
     prompt_path = prompt_file or Path(__file__).parent.parent / "prompts" / "check-for-tasks-default.prompt"
     if not prompt_path.is_file():
@@ -51,11 +64,18 @@ def check_for_tasks(
         raise typer.Exit(code=1)
 
     try:
+        extras_paths = [extras_dir] if extras_dir else []
+        extras_data = extras.load_extras(extras_paths)
+        alias_map = extras.build_alias_map(extras_data)
         journals_data = (
-            journals.load_journals(journal_dir, journal_days=journal_days)
+            journals.load_journals(
+                journal_dir,
+                journal_days=journal_days,
+                alias_map=alias_map,
+            )
             if journal_dir
             else []
-        )
+        ) + extras_data
         emails = gmail.load_emails(datetime.today().date(), gmail_labels=gmail_labels)
         slack_data = (
             slack_loader.load_slack_messages(days_lookback=slack_days)
@@ -69,13 +89,112 @@ def check_for_tasks(
         open_tasks = todoist.load_open_tasks(todoist_project=todoist_project or "")
         bio = os.getenv("BIO", "")
 
+        def _score_entry(entry: dict) -> tuple[float, list[str]]:
+            content = entry.get("content", "")
+            tokens = _TOKEN_RE.findall(content.lower())
+            reasons: list[str] = []
+            score = 0.0
+            for pat in _TASK_PATTERNS:
+                if pat.search(content):
+                    score += 50.0
+                    reasons.append("task phrase")
+                    break
+            for alias in alias_map.keys():
+                if alias.lower() in content.lower():
+                    score += 20.0
+                    reasons.append(f"alias:{alias}")
+                    break
+            if tokens:
+                score += len(set(tokens)) / len(tokens) * 10.0
+                score += len(tokens) * 0.1
+            return score, reasons
+
+        def _compress_group(name: str, entries: List[dict], remaining: int) -> tuple[List[dict], int]:
+            if not entries or remaining <= 0:
+                logger.warning("No budget left for %s", name)
+                return [], 0
+            ranked = []
+            for e in entries:
+                sc, reasons = _score_entry(e)
+                ranked.append((e, sc, reasons))
+            ranked.sort(key=lambda x: x[1], reverse=True)
+            out: List[dict] = []
+            used = 0
+            for entry, sc, reasons in ranked:
+                summary = summarize_text(entry["content"])
+                tokens = estimate_tokens(summary)
+                entry_id = entry.get("filename") or entry.get("id")
+                logger.debug("%s candidate %s tokens=%d reasons=%s", name, entry_id, tokens, ",".join(reasons))
+                if used + tokens > remaining:
+                    logger.debug(
+                        "%s excluded %s due to budget (needed %d remaining %d)",
+                        name,
+                        entry_id,
+                        tokens,
+                        remaining - used,
+                    )
+                    continue
+                new_e = entry.copy()
+                new_e["content"] = summary
+                new_e["token_count"] = tokens
+                out.append(new_e)
+                used += tokens
+                if used >= remaining:
+                    break
+            logger.debug("%s before=%d after=%d tokens=%d", name, len(entries), len(out), used)
+            return out, used
+
+        remaining = token_budget
+
+        journal_docs = [
+            {"id": j.get("filename", "j"), "content": j["content"], "metadata": j}
+            for j in journals_data
+        ]
+        journal_docs, used = _compress_group("journal", journal_docs, remaining)
+        remaining -= used
+        journals_data = [d["metadata"] | {"content": d["content"], "token_count": d["token_count"]} for d in journal_docs]
+
+        email_docs = [
+            {
+                "id": f"{label}-{i}",
+                "content": f"{m.get('subject','')} {m.get('body','')}",
+                "metadata": {**m, "label": label},
+            }
+            for label, msgs in emails.items()
+            for i, m in enumerate(msgs)
+        ]
+        email_docs, used = _compress_group("email", email_docs, remaining)
+        remaining -= used
+        filtered_emails: dict[str, List[dict]] = {}
+        for d in email_docs:
+            meta = d["metadata"].copy()
+            meta["body"] = d["content"]
+            filtered_emails.setdefault(meta.get("label", "inbox"), []).append(meta)
+
+        slack_docs = [
+            {
+                "id": f"{chan}-{i}",
+                "content": msg.get("text", "") + " " + " ".join(r.get("text", "") for r in msg.get("replies", [])),
+                "metadata": {**msg, "channel": chan},
+            }
+            for chan, msgs in slack_data.items()
+            for i, msg in enumerate(msgs)
+        ]
+        slack_docs, used = _compress_group("slack", slack_docs, remaining)
+        remaining -= used
+        filtered_slack: dict[str, List[dict]] = {}
+        for d in slack_docs:
+            meta = d["metadata"].copy()
+            meta["text"] = d["content"]
+            filtered_slack.setdefault(meta.get("channel", ""), []).append(meta)
+
         summary = summarize_check_for_tasks(
             model=model,
             journals=journals_data,
-            emails=emails,
+            emails=filtered_emails,
             completed_tasks=completed_tasks,
             open_tasks=open_tasks,
-            slack=slack_data,
+            slack=filtered_slack,
             bio=bio,
             prompt_path=prompt_path,
             quiet=quiet,

--- a/vea/cli/daily.py
+++ b/vea/cli/daily.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
+import logging
+
 import typer
 
 from ..loaders import gcal, gmail, journals, extras, todoist, slack as slack_loader
@@ -12,11 +14,13 @@ from ..utils.date_utils import parse_date
 from ..utils.output_utils import resolve_output_path
 from ..utils.error_utils import enable_debug_logging, handle_exception
 from ..utils.summarization import summarize_daily
+from ..utils.filtering import run_pipeline
 from ..utils.slack_utils import send_slack_dm
 from ..utils.pdf_utils import convert_markdown_to_pdf
 from ..utils.generic_utils import check_required_directories
 
 app = typer.Typer()
+logger = logging.getLogger(__name__)
 
 
 @app.command("daily")
@@ -50,6 +54,12 @@ def generate(
     model: str = typer.Option(
         "gemini-2.5-pro-preview-06-05", help="Model to use for summarization (OpenAI, Google Gemini, or Anthropic)"
     ),
+    token_budget: int = typer.Option(10000, help="Token budget for filtering contextual documents"),
+    budget_scope: str = typer.Option(
+        "global",
+        help="How to apply the token budget: 'global' for all docs combined or 'group' per source",
+    ),
+    focus_topics_override: Optional[List[str]] = typer.Option(None, help="Override focus topics for filtering"),
     skip_path_checks: bool = typer.Option(False, help="Skip checks for existence of input and output paths"),
     debug: bool = typer.Option(False, help="Enable debug logging"),
     quiet: bool = typer.Option(False, help="Suppress output to stdout"),
@@ -93,17 +103,159 @@ def generate(
             if include_slack
             else {}
         )
+
+        # --- Build focus topics from events and tasks ---
+        focus_topics: List[str] = []
+        for ev in calendars:
+            if ev.get("summary"):
+                focus_topics.append(ev["summary"])
+            if ev.get("description"):
+                focus_topics.append(ev["description"])
+            for att in ev.get("attendees", []):
+                if att.get("name"):
+                    focus_topics.append(att["name"])
+                if att.get("email"):
+                    focus_topics.append(att["email"])
+        for task in tasks:
+            focus_topics.append(task["content"])
+            if task.get("description"):
+                focus_topics.append(task["description"])
+        # boost with known aliases
+        focus_topics.extend(alias_map.keys())
+        if focus_topics_override:
+            focus_topics = list(focus_topics_override)
+
+        logger.debug("Focus topics: %s", focus_topics)
+
+        # --- Helper to filter a single group of documents ---
+        def _filter_group(name: str, docs: List[dict]) -> List[dict]:
+            if not docs:
+                logger.warning("No %s documents to filter", name)
+                return []
+            result = run_pipeline(
+                docs,
+                focus_topics,
+                token_budget=token_budget,
+                return_scores=debug,
+            )
+            logger.debug(
+                "%s docs before=%d after=%d tokens=%d",
+                name,
+                len(docs),
+                len(result["documents"]),
+                result["total_tokens"],
+            )
+            for d in result["documents"]:
+                logger.debug(
+                    "%s kept %s score=%.2f tokens=%d",
+                    name,
+                    d["id"],
+                    d.get("combined_score", 0.0),
+                    d["token_count"],
+                )
+            if not result["documents"]:
+                logger.warning("No %s documents retained after filtering", name)
+            return result["documents"]
+
+        # --- Build document dictionaries and filter ---
+        journal_docs = [
+            {"id": j["filename"], "type": "journal", "content": j["content"], "metadata": {"date": str(j.get("date"))}, "original": j}
+            for j in journals_data
+        ]
+        extras_docs = [
+            {"id": e["filename"], "type": "extra", "content": e["content"], "metadata": {"aliases": e.get("aliases", [])}, "original": e}
+            for e in extras_data
+        ]
+        email_docs = [
+            {
+                "id": f"{label}-{i}",
+                "type": "email",
+                "content": f"{m.get('subject','')} {m.get('body','')}",
+                "metadata": {**m, "label": label},
+                "original": m,
+            }
+            for label, msgs in emails.items()
+            for i, m in enumerate(msgs)
+        ]
+        slack_docs = [
+            {
+                "id": f"{chan}-{i}",
+                "type": "slack",
+                "content": msg.get("text", "") + " " + " ".join(r.get("text", "") for r in msg.get("replies", [])),
+                "metadata": {**msg, "channel": chan},
+                "original": msg,
+            }
+            for chan, msgs in slack_data.items()
+            for i, msg in enumerate(msgs)
+        ]
+
+        if budget_scope.lower() == "group":
+            filtered_journals = [d["original"] for d in _filter_group("journal", journal_docs)]
+            filtered_extras = [d["original"] for d in _filter_group("extra", extras_docs)]
+            _email_results = _filter_group("email", email_docs)
+            _slack_results = _filter_group("slack", slack_docs)
+        else:
+            all_docs = journal_docs + extras_docs + email_docs + slack_docs
+            result = run_pipeline(all_docs, focus_topics, token_budget=token_budget, return_scores=debug)
+            logger.debug(
+                "All docs before=%d after=%d tokens=%d",
+                len(all_docs),
+                len(result["documents"]),
+                result["total_tokens"],
+            )
+            _email_results = []
+            _slack_results = []
+            filtered_journals = []
+            filtered_extras = []
+            for d in result["documents"]:
+                logger.debug(
+                    "%s kept %s score=%.2f tokens=%d",
+                    d["type"],
+                    d["id"],
+                    d.get("combined_score", 0.0),
+                    d["token_count"],
+                )
+                if d["type"] == "journal":
+                    filtered_journals.append(d["original"])
+                elif d["type"] == "extra":
+                    filtered_extras.append(d["original"])
+                elif d["type"] == "email":
+                    _email_results.append(d)
+                elif d["type"] == "slack":
+                    _slack_results.append(d)
+            if not result["documents"]:
+                logger.warning("No documents retained after filtering")
+
+        filtered_emails: dict[str, List[dict]] = {}
+        for d in _email_results:
+            label = d["metadata"].get("label", "inbox")
+            filtered_emails.setdefault(label, []).append(d["original"])
+
+        filtered_slack: dict[str, List[dict]] = {}
+        for d in _slack_results:
+            chan = d["metadata"].get("channel", "")
+            filtered_slack.setdefault(chan, []).append(d["original"])
+
+        if not filtered_journals:
+            logger.warning("No journal documents retained after filtering")
+        if not filtered_extras:
+            logger.warning("No extra documents retained after filtering")
+        if all(len(v) == 0 for v in filtered_emails.values()):
+            logger.warning("No email documents retained after filtering")
+        if all(len(v) == 0 for v in filtered_slack.values()):
+            logger.warning("No Slack messages retained after filtering")
+
         bio = os.getenv("BIO", "")
 
         summary = summarize_daily(
             model=model,
             date=target_date,
-            emails=emails,
+            emails=filtered_emails,
             calendars=calendars,
             tasks=tasks,
-            journals=journals_data,
-            extras=extras_data,
-            slack=slack_data,
+            journals=filtered_journals,
+            extras=filtered_extras,
+            slack=filtered_slack,
             bio=bio,
             prompt_path=prompt_path,
             quiet=quiet,

--- a/vea/cli/prepare_event.py
+++ b/vea/cli/prepare_event.py
@@ -12,6 +12,9 @@ from ..utils.event_utils import (
     find_upcoming_events,
     find_current_events,
 )
+from ..utils.filtering import run_pipeline
+
+import logging
 from ..utils.output_utils import resolve_output_path
 from ..utils.error_utils import enable_debug_logging, handle_exception
 from ..utils.summarization import summarize_event_preparation
@@ -20,6 +23,7 @@ from ..utils.pdf_utils import convert_markdown_to_pdf
 from ..utils.generic_utils import check_required_directories
 
 app = typer.Typer()
+logger = logging.getLogger(__name__)
 
 
 @app.command("prepare-event")
@@ -53,6 +57,8 @@ def prepare_event(
     save_path: Optional[Path] = typer.Option(None, help="Custom file path or directory to save the output"),
     prompt_file: Optional[Path] = typer.Option(None, help="Path to custom prompt file"),
     model: str = typer.Option("gemini-2.5-pro-preview-06-05", help="Model to use for summarization"),
+    token_budget: int = typer.Option(10000, help="Token budget for filtering contextual documents"),
+    focus_topics_override: Optional[List[str]] = typer.Option(None, help="Override focus topics for filtering"),
     skip_path_checks: bool = typer.Option(False, help="Skip checks for existence of input and output paths"),
     debug: bool = typer.Option(False, help="Enable debug logging"),
     quiet: bool = typer.Option(False, help="Suppress output to stdout"),
@@ -128,16 +134,116 @@ def prepare_event(
             if include_slack
             else {}
         )
+        focus_topics: List[str] = []
+        for ev in events:
+            logger.debug(
+                "Event: summary=%s desc=%s", ev.get("summary"), ev.get("description")
+            )
+            if ev.get("summary"):
+                focus_topics.append(ev["summary"])
+            if ev.get("description"):
+                focus_topics.append(ev["description"])
+            for at in ev.get("attendees", []):
+                for key in ("name", "displayName", "email"):
+                    val = at.get(key)
+                    if val:
+                        focus_topics.append(val)
+            org = ev.get("organizer", {})
+            for key in ("displayName", "email"):
+                val = org.get(key)
+                if val:
+                    focus_topics.append(val)
+        focus_topics.extend(alias_map.keys())
+        if focus_topics_override:
+            focus_topics = list(focus_topics_override)
+
+        logger.debug("Focus topics: %s", focus_topics)
+
+        def _filter_group(name: str, docs: List[dict]) -> List[dict]:
+            if not docs:
+                logger.warning("No %s documents to filter", name)
+                return []
+            result = run_pipeline(
+                docs,
+                focus_topics,
+                token_budget=token_budget,
+                return_scores=debug,
+            )
+            logger.debug(
+                "%s docs before=%d after=%d tokens=%d",
+                name,
+                len(docs),
+                len(result["documents"]),
+                result["total_tokens"],
+            )
+            for d in result["documents"]:
+                logger.debug(
+                    "%s kept %s score=%.2f tokens=%d",
+                    name,
+                    d["id"],
+                    d.get("combined_score", 0.0),
+                    d["token_count"],
+                )
+            if not result["documents"]:
+                logger.warning("No %s documents retained after filtering", name)
+            return [d["original"] for d in result["documents"]]
+
+        journal_docs = [
+            {"id": j["filename"], "type": "journal", "content": j["content"], "metadata": {"date": str(j.get("date"))}, "original": j}
+            for j in journals_data
+        ]
+        extras_docs = [
+            {"id": e["filename"], "type": "extra", "content": e["content"], "metadata": {"aliases": e.get("aliases", [])}, "original": e}
+            for e in extras_data
+        ]
+        email_docs = [
+            {
+                "id": f"{label}-{i}",
+                "type": "email",
+                "content": f"{m.get('subject','')} {m.get('body','')}",
+                "metadata": {**m, "label": label},
+                "original": m,
+            }
+            for label, msgs in emails.items()
+            for i, m in enumerate(msgs)
+        ]
+        slack_docs = [
+            {
+                "id": f"{chan}-{i}",
+                "type": "slack",
+                "content": msg.get("text", "") + " " + " ".join(r.get("text", "") for r in msg.get("replies", [])),
+                "metadata": {**msg, "channel": chan},
+                "original": msg,
+            }
+            for chan, msgs in slack_data.items()
+            for i, msg in enumerate(msgs)
+        ]
+
+        filtered_journals = _filter_group("journal", journal_docs)
+        filtered_extras = _filter_group("extra", extras_docs)
+        filtered_email_docs = _filter_group("email", email_docs)
+        filtered_slack_docs = _filter_group("slack", slack_docs)
+
+        filtered_emails: dict[str, List[dict]] = {}
+        for d in filtered_email_docs:
+            label = d.get("label", "inbox")
+            filtered_emails.setdefault(label, []).append(d)
+
+        filtered_slack: dict[str, List[dict]] = {}
+        for d in filtered_slack_docs:
+            chan = d.get("channel", "")
+            filtered_slack.setdefault(chan, []).append(d)
+
         bio = os.getenv("BIO", "")
 
         summary = summarize_event_preparation(
             model=model,
             events=events,
-            journals=journals_data,
-            extras=extras_data,
-            emails=emails,
+            journals=filtered_journals,
+            extras=filtered_extras,
+            emails=filtered_emails,
             tasks=tasks,
-            slack=slack_data,
+            slack=filtered_slack,
             bio=bio,
             prompt_path=prompt_path,
             quiet=quiet,

--- a/vea/cli/weekly.py
+++ b/vea/cli/weekly.py
@@ -1,11 +1,13 @@
 import os
+import logging
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
 import typer
 
-from ..loaders import gcal, journals, extras
+from ..loaders import journals, extras
 from ..loaders.journals import load_journals
 from ..loaders.extras import load_extras
 from ..utils.date_utils import parse_week_input
@@ -14,6 +16,12 @@ from ..utils.error_utils import enable_debug_logging, handle_exception
 from ..utils.summarization import summarize_weekly
 from ..utils.pdf_utils import convert_markdown_to_pdf
 from ..utils.generic_utils import check_required_directories
+from ..utils.text_utils import estimate_tokens, summarize_text
+
+
+logger = logging.getLogger(__name__)
+
+_TOKEN_RE = re.compile(r"\b\w+\b")
 
 app = typer.Typer()
 
@@ -34,6 +42,7 @@ def generate_weekly_summary(
     model: str = typer.Option(
         "gemini-2.5-pro-preview-06-05", help="Model to use for summarization (OpenAI, Google Gemini, or Anthropic)"
     ),
+    token_budget: int = typer.Option(10000, help="Token budget for summarized context"),
     skip_path_checks: bool = typer.Option(False, help="Skip path existence checks."),
     debug: bool = typer.Option(False, help="Enable debug logging"),
     quiet: bool = typer.Option(False, help="Suppress output to stdout"),
@@ -62,12 +71,79 @@ def generate_weekly_summary(
             latest_date=week_end,
         )
 
+        def _score_entry(entry: dict) -> float:
+            content = entry.get("content", "")
+            tokens = _TOKEN_RE.findall(content.lower())
+            if not tokens:
+                return 0.0
+            unique_words = len(set(tokens))
+            density = unique_words / len(tokens)
+
+            alias_bonus = 0.0
+            for alias in alias_map.keys():
+                if alias.lower() in content.lower():
+                    alias_bonus = 100.0
+                    break
+
+            recency = 0.0
+            if "date" in entry and entry["date"]:
+                recency = max(0, 7 - (week_end - entry["date"]).days) * 10.0
+
+            return len(tokens) * density + alias_bonus + recency
+
+        def _compress_group(name: str, entries: List[dict], remaining: int) -> tuple[List[dict], int]:
+            if not entries or remaining <= 0:
+                logger.warning("No budget left for %s", name)
+                return [], 0
+
+            ranked = sorted(entries, key=_score_entry, reverse=True)
+            out: List[dict] = []
+            used = 0
+            for entry in ranked:
+                summary = summarize_text(entry["content"])
+                tokens = estimate_tokens(summary)
+                entry_id = entry.get("filename") or entry.get("id")
+                logger.debug("%s candidate %s tokens=%d", name, entry_id, tokens)
+                if used + tokens > remaining:
+                    logger.debug(
+                        "%s excluded %s due to budget (needed %d remaining %d)",
+                        name,
+                        entry_id,
+                        tokens,
+                        remaining - used,
+                    )
+                    continue
+                new_e = entry.copy()
+                new_e["content"] = summary
+                new_e["token_count"] = tokens
+                out.append(new_e)
+                used += tokens
+            logger.debug(
+                "%s before=%d after=%d tokens=%d",
+                name,
+                len(entries),
+                len(out),
+                used,
+            )
+            return out, used
+
         def journal_in_week(entry: dict) -> bool:
             return "date" in entry and week_start <= entry["date"] <= week_end
 
         journals_in_week = [e for e in all_journals if journal_in_week(e)]
         journals_contextual = [e for e in all_journals if not journal_in_week(e)]
         extras_data = all_extras
+
+        remaining = token_budget
+        journals_in_week, used = _compress_group("week_journals", journals_in_week, remaining)
+        remaining -= used
+        journals_contextual, used = _compress_group("context_journals", journals_contextual, remaining)
+        remaining -= used
+        extras_data, used = _compress_group("extras", extras_data, remaining)
+        remaining -= used
+
+        logger.debug("Total tokens used %d of %d", token_budget - remaining, token_budget)
+
         bio = os.getenv("BIO", "")
 
         summary = summarize_weekly(

--- a/vea/utils/filtering.py
+++ b/vea/utils/filtering.py
@@ -1,0 +1,331 @@
+"""Utility utilities for ranking and filtering text documents.
+
+The module exposes a pluggable architecture for determining the relevance of a
+piece of text given a list of focus topics.  In previous iterations this module
+only exposed the :class:`BaseRanker` class and a ``filter_documents`` function.
+The API has been expanded with a more explicit ``RelevanceStrategy`` interface
+and a small :class:`RelevanceFilterPipeline` for combining multiple strategies.
+
+The original classes are kept as aliases so existing imports keep working.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Tuple
+
+try:  # Optional dependency used for token counting
+    import tiktoken  # type: ignore
+except Exception:  # pragma: no cover - optional
+    tiktoken = None
+
+__all__ = [
+    "RelevanceStrategy",
+    "TFIDFStrategy",
+    "KeywordMatchStrategy",
+    "EmbeddingSimilarityStrategy",
+    "RelevanceFilterPipeline",
+    "filter_documents",
+    "BaseRanker",
+    "TfidfRanker",
+    "KeywordRanker",
+]
+
+
+_TOKEN_RE = re.compile(r"\b\w+\b")
+
+_STOP_WORDS = {
+    "a",
+    "an",
+    "the",
+    "and",
+    "or",
+    "if",
+    "of",
+    "to",
+    "in",
+    "for",
+    "with",
+    "on",
+    "at",
+    "by",
+    "from",
+    "as",
+    "is",
+    "are",
+    "was",
+    "were",
+    "be",
+    "been",
+    "being",
+    "have",
+    "has",
+    "had",
+    "do",
+    "does",
+    "did",
+    "this",
+    "that",
+    "these",
+    "those",
+    "i",
+    "me",
+    "my",
+    "we",
+    "our",
+    "you",
+    "your",
+    "he",
+    "she",
+    "it",
+    "they",
+    "them",
+    "their",
+    "not",
+}
+
+
+def _tokenize(text: str) -> List[str]:
+    return _TOKEN_RE.findall(text.lower())
+
+
+def _preprocess(text: str) -> List[str]:
+    """Tokenize and remove very common stop words."""
+    return [t for t in _tokenize(text) if t not in _STOP_WORDS]
+
+
+def _estimate_tokens(text: str) -> int:
+    """Best-effort token count using tiktoken when available.
+
+    Falls back to a naive heuristic of ~1.3 tokens per word when the
+    ``tiktoken`` package is not installed.
+    """
+    if tiktoken is not None:
+        try:
+            enc = tiktoken.get_encoding("cl100k_base")
+            return len(enc.encode(text))
+        except Exception:  # pragma: no cover - unexpected
+            pass
+    # naive fallback: assume ~1.3 tokens per word
+    return max(1, int(len(_tokenize(text)) * 1.3))
+
+
+@dataclass
+class RelevanceStrategy:
+    """Base class for relevance scoring strategies."""
+
+    preprocess: bool = True
+
+    def _prep(self, text: str) -> List[str]:
+        return _preprocess(text) if self.preprocess else _tokenize(text)
+
+    def score(self, doc: str, topics: List[str]) -> float:  # pragma: no cover - abstract
+        """Return a numeric relevance score for ``doc`` given ``topics``."""
+        raise NotImplementedError
+
+    def rank(self, docs: Iterable[str], topics: List[str]) -> List[Tuple[str, float]]:
+        """Return ``docs`` sorted by descending score."""
+        scored = [(doc, self.score(doc, topics)) for doc in docs]
+        return sorted(scored, key=lambda x: x[1], reverse=True)
+
+
+# Backwards compatible alias
+BaseRanker = RelevanceStrategy
+
+
+@dataclass
+class TFIDFStrategy(RelevanceStrategy):
+    """Rank documents based on cosine similarity using a minimal TF–IDF model."""
+
+    def _build_idf(self, docs: Iterable[str]) -> Dict[str, float]:
+        df: Dict[str, int] = defaultdict(int)
+        doc_count = 0
+        for doc in docs:
+            tokens = set(self._prep(doc))
+            for token in tokens:
+                df[token] += 1
+            doc_count += 1
+        return {t: math.log((doc_count + 1) / (n + 1)) + 1 for t, n in df.items()}
+
+    def _tfidf(self, tokens: List[str], idf: Dict[str, float]) -> Dict[str, float]:
+        if not tokens:
+            return {}
+        counts = Counter(tokens)
+        total = len(tokens)
+        return {t: (counts[t] / total) * idf.get(t, 0.0) for t in counts}
+
+    def score(self, doc: str, topics: List[str]) -> float:
+        # Build IDF from both the candidate document and the topics.
+        idf = self._build_idf([doc] + topics)
+        doc_vec = self._tfidf(self._prep(doc), idf)
+        topic_vec = self._tfidf(self._prep(" ".join(topics)), idf)
+
+        # Cosine similarity without numpy.
+        if not doc_vec or not topic_vec:
+            return 0.0
+        dot = sum(doc_vec.get(t, 0.0) * topic_vec.get(t, 0.0) for t in set(doc_vec) | set(topic_vec))
+        norm_doc = math.sqrt(sum(v * v for v in doc_vec.values()))
+        norm_topic = math.sqrt(sum(v * v for v in topic_vec.values()))
+        if norm_doc == 0 or norm_topic == 0:
+            return 0.0
+        return dot / (norm_doc * norm_topic)
+
+
+@dataclass
+class KeywordMatchStrategy(RelevanceStrategy):
+    """Simpler ranker based on shared keyword count."""
+
+    def score(self, doc: str, topics: List[str]) -> float:
+        doc_tokens = set(self._prep(doc))
+        topic_tokens = set(self._prep(" ".join(topics)))
+        if not doc_tokens:
+            return 0.0
+        return len(doc_tokens & topic_tokens) / len(doc_tokens)
+
+
+class EmbeddingSimilarityStrategy(RelevanceStrategy):
+    """Strategy based on cosine similarity between document embeddings.
+
+    This class requires ``sentence-transformers`` to be installed.  If the
+    package is missing, an informative ImportError is raised when ``score`` is
+    called.  The implementation is intentionally lightweight so tests can run
+    without the optional dependency.
+    """
+
+    def __init__(self, model_name: str = "all-MiniLM-L6-v2") -> None:
+        self.model_name = model_name
+        self._model = None
+
+    def _ensure_model(self):
+        if self._model is None:
+            try:
+                from sentence_transformers import SentenceTransformer
+            except Exception as exc:  # pragma: no cover - optional dependency
+                raise ImportError(
+                    "sentence-transformers is required for EmbeddingSimilarityStrategy"
+                ) from exc
+            self._model = SentenceTransformer(self.model_name)
+
+    def score(self, doc: str, topics: List[str]) -> float:
+        self._ensure_model()
+        embeddings = self._model.encode([doc, " ".join(topics)])
+        a, b = embeddings
+        # Manual cosine similarity to avoid numpy requirement
+        dot = sum(x * y for x, y in zip(a, b))
+        norm_a = math.sqrt(sum(x * x for x in a))
+        norm_b = math.sqrt(sum(x * x for x in b))
+        if norm_a == 0 or norm_b == 0:
+            return 0.0
+        return dot / (norm_a * norm_b)
+
+
+@dataclass
+class RelevanceFilterPipeline:
+    """Filter and rank document dictionaries using one or more strategies."""
+
+    strategies: List[tuple[RelevanceStrategy, float]] | None = None
+    max_documents: int | None = None
+    token_budget: int | None = None
+
+    def _normalized_strategies(self) -> List[tuple[RelevanceStrategy, float]]:
+        if not self.strategies:
+            return [(TFIDFStrategy(), 1.0)]
+        norm = []
+        for item in self.strategies:
+            if isinstance(item, tuple):
+                strat, weight = item
+            else:
+                strat, weight = item, 1.0
+            norm.append((strat, weight))
+        return norm
+
+    def _rank(self, docs: List[dict], topics: List[str]):
+        strats = self._normalized_strategies()
+        total_weight = sum(w for _, w in strats)
+        results = []
+        for doc in docs:
+            scores = {}
+            combined = 0.0
+            for strat, weight in strats:
+                sc = strat.score(doc["content"], topics)
+                sc = max(0.0, min(1.0, sc))
+                scores[type(strat).__name__] = sc
+                combined += sc * weight
+            combined = combined / total_weight if strats else 0.0
+            results.append((doc, combined, scores))
+        results.sort(key=lambda x: x[1], reverse=True)
+        return results
+
+    def filter(self, docs: List[dict], topics: List[str], *, return_scores: bool = False) -> dict:
+        ranked = self._rank(docs, topics)
+        selected: List[dict] = []
+        tokens_used = 0
+        for doc, combined, scores in ranked:
+            if self.max_documents is not None and len(selected) >= self.max_documents:
+                break
+            doc_tokens = _estimate_tokens(doc["content"])
+            if self.token_budget is not None and doc_tokens > self.token_budget - tokens_used:
+                continue
+            out = doc.copy()
+            out["token_count"] = doc_tokens
+            if return_scores:
+                out["strategy_scores"] = scores
+                out["combined_score"] = combined
+            selected.append(out)
+            tokens_used += doc_tokens
+            if self.token_budget is not None and tokens_used >= self.token_budget:
+                break
+        return {"documents": selected, "total_tokens": tokens_used}
+
+
+def run_pipeline(
+    docs: List[dict],
+    topics: List[str],
+    *,
+    strategies: List[tuple[RelevanceStrategy, float] | RelevanceStrategy] | None = None,
+    max_documents: int | None = None,
+    token_budget: int | None = None,
+    return_scores: bool = False,
+) -> dict:
+    """Convenience wrapper around :class:`RelevanceFilterPipeline`."""
+
+    pipeline = RelevanceFilterPipeline(
+        strategies=strategies,
+        max_documents=max_documents,
+        token_budget=token_budget,
+    )
+    return pipeline.filter(docs, topics, return_scores=return_scores)
+
+
+# Backwards compatible class names
+TfidfRanker = TFIDFStrategy
+KeywordRanker = KeywordMatchStrategy
+
+
+def filter_documents(
+    docs: List[str],
+    topics: List[str],
+    *,
+    ranker: RelevanceStrategy | None = None,
+    top_n: int | None = None,
+    threshold: float | None = None,
+) -> List[str]:
+    """Return documents ranked most relevant to ``topics``.
+
+    ``top_n`` limits the number of results. ``threshold`` filters by minimum
+    similarity score.
+    """
+
+    ranker = ranker or TFIDFStrategy()
+    ranked = ranker.rank(docs, topics)
+
+    if threshold is not None:
+        ranked = [pair for pair in ranked if pair[1] >= threshold]
+
+    if top_n is not None:
+        ranked = ranked[:top_n]
+
+    return [doc for doc, _ in ranked]

--- a/vea/utils/summarization.py
+++ b/vea/utils/summarization.py
@@ -41,22 +41,8 @@ def render_daily_prompt(
         emails=emails,
         journals=journals,
         extras=extras,
-        slack=slack
+        slack=slack,
     )
-
-'''
-prompt = render_daily_prompt(
-        prompt_template,
-        date=date,
-        bio=bio,
-        calendars=str(calendars),
-        tasks=str(tasks),
-        emails=str(emails),
-        journals=str(journals),
-        extras=str(extras),
-        slack=str(slack) if slack else ""
-    )
-'''
 
 
 def summarize_daily(

--- a/vea/utils/text_utils.py
+++ b/vea/utils/text_utils.py
@@ -1,0 +1,64 @@
+import re
+from typing import List
+
+try:
+    from sumy.nlp.tokenizers import Tokenizer  # type: ignore
+    from sumy.parsers.plaintext import PlaintextParser  # type: ignore
+    from sumy.summarizers.text_rank import TextRankSummarizer  # type: ignore
+except Exception:  # pragma: no cover - optional
+    PlaintextParser = None
+
+try:  # optional dependency
+    import tiktoken  # type: ignore
+except Exception:  # pragma: no cover - optional
+    tiktoken = None
+
+TOKEN_RE = re.compile(r"\b\w+\b")
+
+
+def estimate_tokens(text: str) -> int:
+    """Return a best-effort token count for ``text``."""
+    if tiktoken is not None:
+        try:
+            enc = tiktoken.get_encoding("cl100k_base")
+            return len(enc.encode(text))
+        except Exception:  # pragma: no cover - unexpected
+            pass
+    return max(1, int(len(TOKEN_RE.findall(text)) * 1.3))
+
+
+def summarize_text(text: str, max_sentences: int = 2) -> str:
+    """Extract a brief summary of ``text``.
+
+    Uses TextRank from ``sumy`` when available. If not, chooses the most
+    information-dense sentences based on token uniqueness and length.
+    """
+    if PlaintextParser is not None:  # pragma: no cover - optional
+        parser = PlaintextParser.from_string(text, Tokenizer("english"))
+        summarizer = TextRankSummarizer()
+        sentences = summarizer(parser.document, max_sentences)
+        out = " ".join(str(s) for s in sentences)
+        if out:
+            return out
+
+    sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", text.strip()) if s.strip()]
+    if not sentences:
+        return ""
+    if len(sentences) <= max_sentences:
+        return " ".join(sentences)
+
+    words = TOKEN_RE.findall(text.lower())
+    freq: dict[str, int] = {}
+    for w in words:
+        freq[w] = freq.get(w, 0) + 1
+
+    def score(sentence: str) -> float:
+        tokens = TOKEN_RE.findall(sentence.lower())
+        if re.match(r"^(hi|hello|hey)\b", sentence.lower()):
+            return 0.0
+        uniq = sum(1.0 / freq.get(t, 1) for t in tokens)
+        length = len(tokens)
+        return uniq + 0.1 * length
+
+    ranked = sorted(sentences, key=score, reverse=True)
+    return " ".join(ranked[:max_sentences])


### PR DESCRIPTION
## Summary
- support token budgets with a tiktoken fallback
- add optional score transparency for each relevance strategy
- allow weighting of strategies and document preprocessing
- update helper and tests for new filtering results
- clamp strategy scores to [0, 1] and skip oversized docs for token budgets
- add tests for normalization and budget skipping
- integrate the filtering pipeline into the daily CLI
- test that the daily command invokes the pipeline when generating a briefing
- add configurable budget scope and detailed debug logging
- ensure empty groups do not crash the daily summary
- integrate relevance filtering into the prepare-event CLI
- test prepare-event filtering behavior
- include participant names/emails in focus topics and add debug logs
- compress weekly inputs to respect a token budget using extractive summaries
- add tests ensuring weekly compression trims journal entries
- improve fallback summarization and ranking in weekly compression
- filter check-for-tasks input
- set default token budgets to 10000 across the CLI
- document the new filtering flags and defaults in README
- share helper functions for estimating tokens and summarizing text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a7caedb4832c81b62596b0f58a07