### PR TITLE
Support journal outliner sub-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ vea daily \
   --save-markdown
 ```
 
+Journal entries are split into top-level bullets for filtering so only the most
+relevant sections are included. Use `--no-outliner-mode` to treat each file as a
+single document.
+
 ### Daily command options
 
 Below is a complete list of options for `vea daily` (run `vea daily --help` to see this at any time):
@@ -75,6 +79,7 @@ Below is a complete list of options for `vea daily` (run `vea daily --help` to s
 - `--date` – Date to generate the brief for (defaults to today)
 - `--journal-dir` – Directory with Markdown journal files (named like `YYYY-MM-DD.md`)
 - `--journal-days` – Number of past journal days to include (default: 21)
+- `--outliner-mode / --no-outliner-mode` – Enable or disable outliner-style parsing for journal entries (default: enabled)
 - `--extras-dir` – Directory with extra `.md` files (e.g. notes, projects)
 - `--gmail-labels` – Additional Gmail labels to include besides `inbox` and `sent` mail
 - `--todoist-project` – Filter tasks by Todoist project
@@ -125,7 +130,7 @@ Run `vea weekly --help` to see all options. Key options include:
 
 ### Prepare for an event
 
-Use `vea prepare-event` to get a quick briefing before a meeting. The command collects emails, tasks, notes and Slack messages around the event time and summarizes them with your LLM of choice. By default it looks at the next calendar entry, but you can target a specific moment with the `--event` option.
+Use `vea prepare-event` to get a quick briefing before a meeting. The command collects emails, tasks, notes and Slack messages around the event time and summarizes them with your LLM of choice. By default it looks at the next calendar entry, but you can target a specific moment with the `--event` option. Journal entries are split into bullet blocks (outliner mode) so only relevant snippets are included.
 
 ```bash
 vea prepare-event --lookahead-minutes 30 --slack-dm
@@ -136,6 +141,7 @@ Key options include:
 - `--lookahead-minutes` – How far ahead to search for the next event
 - `--journal-dir` – Directory with Markdown journal files
 - `--journal-days` – Number of past journal days to include (default: 21)
+- `--outliner-mode / --no-outliner-mode` – Enable or disable outliner-style parsing for journal entries (default: enabled)
 - `--slack-days` – Number of past days of Slack messages to load (default: 5)
 - `--slack-dm` – Send the output as a Slack DM to yourself
 - `--token-budget` – Maximum tokens for filtering documents (default: 10000)

--- a/tests/test_daily_filtering.py
+++ b/tests/test_daily_filtering.py
@@ -52,7 +52,14 @@ def test_daily_generate_global_budget(monkeypatch):
     # Patch loader functions to return sample data
     monkeypatch.setattr(daily.extras, "load_extras", lambda paths: [{"filename": "ex1", "content": "alpha note", "aliases": ["Alpha"]}])
     monkeypatch.setattr(daily.extras, "build_alias_map", lambda extras: {"alpha": "ex1"})
-    monkeypatch.setattr(daily.journals, "load_journals", lambda *a, **k: [{"filename": "j1", "content": "alpha journal", "date": datetime(2025,4,30).date()}])
+    monkeypatch.setattr(
+        daily.journals,
+        "load_journals",
+        lambda *a, **k: [
+            {"filename": "j1", "content": "alpha journal", "date": datetime(2025,4,30).date(), "sub_index": 1},
+            {"filename": "j1", "content": "beta journal", "date": datetime(2025,4,30).date(), "sub_index": 2},
+        ],
+    )
     monkeypatch.setattr(daily.gcal, "load_events", lambda *a, **k: [{"summary": "Alpha Meeting", "description": "discuss", "attendees": [{"name": "Alice", "email": "alice@example.com"}]}])
     monkeypatch.setattr(daily.todoist, "load_tasks", lambda *a, **k: [{"content": "Finish alpha", "description": ""}])
     monkeypatch.setattr(daily.gmail, "load_emails", lambda *a, **k: {"inbox": [{"subject": "hello", "from": "alice", "date": "", "body": "alpha"}]})
@@ -96,7 +103,14 @@ def test_daily_generate_global_budget(monkeypatch):
 def test_daily_generate_group_budget(monkeypatch):
     monkeypatch.setattr(daily.extras, "load_extras", lambda paths: [{"filename": "ex1", "content": "alpha note", "aliases": ["Alpha"]}])
     monkeypatch.setattr(daily.extras, "build_alias_map", lambda extras: {"alpha": "ex1"})
-    monkeypatch.setattr(daily.journals, "load_journals", lambda *a, **k: [{"filename": "j1", "content": "alpha journal", "date": datetime(2025,4,30).date()}])
+    monkeypatch.setattr(
+        daily.journals,
+        "load_journals",
+        lambda *a, **k: [
+            {"filename": "j1", "content": "alpha journal", "date": datetime(2025,4,30).date(), "sub_index": 1},
+            {"filename": "j1", "content": "beta journal", "date": datetime(2025,4,30).date(), "sub_index": 2},
+        ],
+    )
     monkeypatch.setattr(daily.gcal, "load_events", lambda *a, **k: [{"summary": "Alpha Meeting"}])
     monkeypatch.setattr(daily.todoist, "load_tasks", lambda *a, **k: [])
     monkeypatch.setattr(daily.gmail, "load_emails", lambda *a, **k: {"inbox": [{"subject": "hello", "body": "alpha"}]})

--- a/tests/test_journal_outliner.py
+++ b/tests/test_journal_outliner.py
@@ -1,0 +1,17 @@
+import datetime
+from pathlib import Path
+from vea.loaders.journals import load_journals
+
+
+def test_outliner_parsing(tmp_path):
+    md = "- item one\n  - child\n- item two\n  continuation"
+    f = tmp_path / "2025-06-05.md"
+    f.write_text(md)
+
+    docs = load_journals(tmp_path, journal_days=10, outliner_mode=True)
+    assert len(docs) == 2
+    assert docs[0]["sub_index"] == 1
+    assert docs[1]["sub_index"] == 2
+    assert docs[0]["content"].startswith("- item one")
+    assert docs[1]["content"].startswith("- item two")
+    assert docs[0]["date"] == datetime.date(2025, 6, 5)

--- a/tests/test_prepare_event_filtering.py
+++ b/tests/test_prepare_event_filtering.py
@@ -50,7 +50,14 @@ import vea.cli.prepare_event as pe
 def test_prepare_event_filters(monkeypatch):
     monkeypatch.setattr(pe.extras, "load_extras", lambda paths: [{"filename": "ex1", "content": "alpha note", "aliases": ["Alpha"]}])
     monkeypatch.setattr(pe.extras, "build_alias_map", lambda extras: {"alpha": "ex1"})
-    monkeypatch.setattr(pe.journals, "load_journals", lambda *a, **k: [{"filename": "j1", "content": "alpha journal", "date": datetime(2025,4,30).date()}])
+    monkeypatch.setattr(
+        pe.journals,
+        "load_journals",
+        lambda *a, **k: [
+            {"filename": "j1", "content": "alpha journal", "date": datetime(2025,4,30).date(), "sub_index": 1},
+            {"filename": "j1", "content": "beta journal", "date": datetime(2025,4,30).date(), "sub_index": 2},
+        ],
+    )
     monkeypatch.setattr(
         pe, "find_upcoming_events", lambda *a, **k: [{"summary": "Alpha Meeting", "description": "discuss", "attendees": [{"name": "Alice", "email": "alice@example.com"}], "start": "2025-05-01T10:00:00"}]
     )

--- a/vea/utils/markdown_utils.py
+++ b/vea/utils/markdown_utils.py
@@ -1,0 +1,22 @@
+"""Markdown parsing utilities."""
+
+import re
+from typing import List
+
+
+def split_outliner_blocks(content: str) -> List[str]:
+    """Return top-level bullets with children from Logseq-style Markdown."""
+    blocks: List[List[str]] = []
+    current: List[str] = []
+    for line in content.splitlines():
+        if re.match(r"^-\s|^-\[", line):
+            if current:
+                blocks.append(current)
+                current = []
+            current.append(line)
+        else:
+            if current:
+                current.append(line)
+    if current:
+        blocks.append(current)
+    return ["\n".join(b).rstrip() for b in blocks]


### PR DESCRIPTION
## Summary
- split journal files into top-level bullet sub-documents
- allow turning the behaviour off with `--outliner-mode/--no-outliner-mode`
- filter and log sub-documents in `daily` and `prepare-event`
- add coverage for outliner parsing
- update filtering tests for new journal structure
- document outliner mode in README
- move split_outliner_blocks helper to utils

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68466f7d19a0832cab9399274a60948c