### PR TITLE
Add support for o3-pro completion endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ Below is a complete list of options for `vea daily` (run `vea daily --help` to s
 - `--save-pdf` – Save the summary as a PDF file
 - `--save-path` – Custom file path or directory for the output
 - `--prompt-file` – Path to a custom prompt file (default: `/prompts/daily-default.prompt`)
-- `--model` – LLM to use for summarization (e.g. `o4-mini`, `claude-3-7-sonnet-latest`, `gemini-2.5-pro-preview-05-06`)
+- `--model` – LLM to use for summarization (e.g. `o4-mini`, `o3-pro-2025-06-10`, `claude-3-7-sonnet-latest`, `gemini-2.5-pro-preview-05-06`)
+- OpenAI's `o3-pro-*` models are supported and use the completions endpoint.
 - `--skip-path-checks` – Skip validation of input/output paths
 - `--debug` – Enable debug logging
 - `--quiet` – Suppress printing the summary to stdout


### PR DESCRIPTION
## Summary
- detect chat vs completion models in `run_llm_prompt`
- call `openai.completions.create` for completion models like `o3-pro-*`
- add helper `is_chat_model`
- log which OpenAI endpoint is used
- document o3-pro model support in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684969412c14832caa5c67d4b5d909a2